### PR TITLE
(#16) Implement Update Management UI

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,3 +23,19 @@ This project:
 - Uses signed releases
 - Verifies checksums before installation
 - Never auto-updates without user consent
+
+## Prototype Network Trust Model
+
+Current development builds are intended for trusted local network use only.
+
+Known limitation:
+- High-impact API actions such as service restart, reboot, and update apply do not yet use a full authentication or authorization model.
+- The current implementation limits browser access by requiring same-host UI origin checks for these endpoints.
+- This is a prototype safeguard, not a complete security boundary.
+
+Until a real authentication mechanism is implemented:
+- Do not expose the API or UI to the public internet.
+- Do not treat these endpoints as safe on untrusted or shared networks.
+- Treat local network access as trusted operator access.
+
+Future hardening work should add authenticated authorization for privileged API actions before any broader deployment.

--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -42,6 +42,10 @@ paths:
   /system/restart:
     post:
       summary: Restart TurboPi services
+      description: >
+        Development prototype endpoint for trusted local-network use.
+        This endpoint currently relies on same-host UI origin checks and does
+        not yet implement full authentication or authorization.
       responses:
         '202':
           description: Restart initiated
@@ -58,6 +62,10 @@ paths:
   /system/reboot:
     post:
       summary: Reboot the robot
+      description: >
+        Development prototype endpoint for trusted local-network use.
+        This endpoint currently relies on same-host UI origin checks and does
+        not yet implement full authentication or authorization.
       responses:
         '202':
           description: Reboot initiated
@@ -87,6 +95,10 @@ paths:
   /updates/apply:
     post:
       summary: Apply latest stable update
+      description: >
+        Development prototype endpoint for trusted local-network use.
+        This endpoint currently relies on same-host UI origin checks and does
+        not yet implement full authentication or authorization.
       responses:
         '200':
           description: No update needed (already on latest version)

--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -45,6 +45,15 @@ paths:
       responses:
         '202':
           description: Restart initiated
+        '403':
+          description: Request origin is not allowed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "forbidden" }
+                  message: { type: string }
 
   /system/reboot:
     post:
@@ -52,6 +61,15 @@ paths:
       responses:
         '202':
           description: Reboot initiated
+        '403':
+          description: Request origin is not allowed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "forbidden" }
+                  message: { type: string }
 
   /updates/check:
     get:
@@ -89,6 +107,15 @@ paths:
                   status: { type: string, example: "update_started" }
                   message: { type: string, example: "Update to version 0.1.5 has been initiated" }
                   version: { type: string, example: "0.1.5" }
+        '403':
+          description: Request origin is not allowed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "forbidden" }
+                  message: { type: string }
         '500':
           description: Failed to fetch release information or verify integrity
           content:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -307,6 +307,10 @@ class APIHandler(BaseHTTPRequestHandler):
         """Handle POST requests"""
         if self.path == '/updates/apply':
             self.handle_updates_apply()
+        elif self.path == '/system/restart':
+            self.handle_system_restart()
+        elif self.path == '/system/reboot':
+            self.handle_system_reboot()
         elif self.path == '/voice/wake-word/config':
             self.handle_wake_word_update_config()
         elif self.path == '/voice/stt':
@@ -375,6 +379,52 @@ class APIHandler(BaseHTTPRequestHandler):
         except Exception as e:
             logging.error(f"System version endpoint error: {str(e)}")
             self.send_error(500, "Internal Server Error: Unable to retrieve version information")
+
+    def handle_system_restart(self):
+        """Handle POST /system/restart — restart all TurboPi systemd services."""
+        self.send_response(202)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'status': 'restart_initiated'}).encode())
+        logging.info("Service restart requested via API")
+
+        def _do_restart():
+            import subprocess
+            import time
+            time.sleep(0.5)
+            try:
+                subprocess.run(
+                    ['systemctl', 'restart',
+                     'turbopi-api', 'turbopi-ui', 'turbopi-updater',
+                     'turbopi-wake-word'],
+                    check=False,
+                    timeout=30
+                )
+            except Exception as exc:
+                logging.error("Service restart error: %s", exc)
+
+        t = threading.Thread(target=_do_restart, daemon=True)
+        t.start()
+
+    def handle_system_reboot(self):
+        """Handle POST /system/reboot — reboot the Raspberry Pi."""
+        self.send_response(202)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'status': 'reboot_initiated'}).encode())
+        logging.info("System reboot requested via API")
+
+        def _do_reboot():
+            import subprocess
+            import time
+            time.sleep(0.5)
+            try:
+                subprocess.run(['reboot'], check=False, timeout=10)
+            except Exception as exc:
+                logging.error("Reboot error: %s", exc)
+
+        t = threading.Thread(target=_do_reboot, daemon=True)
+        t.start()
 
     def handle_updates_check(self):
         """Handle /updates/check endpoint"""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -12,8 +12,11 @@ import os
 import sys
 import json
 import logging
+import subprocess
+import time
 import urllib.request
 import urllib.error
+import urllib.parse
 import threading
 import re
 from typing import Optional, Dict
@@ -38,6 +41,9 @@ try:
 except ImportError:
     COMMAND_PARSER_AVAILABLE = False
     logging.warning("Command intent parser not available")
+
+
+SYSTEM_ACTION_DELAY_SECONDS = 0.5
 
 
 def get_current_version() -> str:
@@ -276,9 +282,79 @@ class APIHandler(BaseHTTPRequestHandler):
                          self.log_date_time_string(),
                          format % args))
 
+    def _send_json_response(self, status_code: int, payload: Dict):
+        """Send a JSON response with the provided status code."""
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode())
+
+    def _get_allowed_ui_origin(self) -> Optional[str]:
+        """Return the allowed UI origin for this request when present."""
+        origin = self.headers.get('Origin')
+        if not origin:
+            return None
+
+        parsed_origin = urllib.parse.urlparse(origin)
+        if parsed_origin.scheme not in ('http', 'https') or not parsed_origin.hostname:
+            return None
+
+        request_host = (self.headers.get('Host') or '').split(':', 1)[0].lower()
+        if not request_host:
+            return None
+
+        ui_port = int(os.environ.get('UI_PORT', '8081'))
+        if parsed_origin.port != ui_port:
+            return None
+
+        if parsed_origin.hostname.lower() != request_host:
+            return None
+
+        return f"{parsed_origin.scheme}://{parsed_origin.netloc}"
+
+    def _require_ui_origin(self) -> bool:
+        """Require a same-host UI origin for dangerous system actions."""
+        header_value = self.headers.get('Origin') or self.headers.get('Referer')
+        if not header_value:
+            self._send_json_response(403, {
+                'error': 'forbidden',
+                'message': 'Requests to this endpoint must originate from the TurboPi UI.'
+            })
+            return False
+
+        parsed_header = urllib.parse.urlparse(header_value)
+        if parsed_header.scheme not in ('http', 'https') or not parsed_header.hostname:
+            self._send_json_response(403, {
+                'error': 'forbidden',
+                'message': 'Requests to this endpoint must originate from the TurboPi UI.'
+            })
+            return False
+
+        request_host = (self.headers.get('Host') or '').split(':', 1)[0].lower()
+        ui_port = int(os.environ.get('UI_PORT', '8081'))
+        if parsed_header.hostname.lower() != request_host or parsed_header.port != ui_port:
+            self._send_json_response(403, {
+                'error': 'forbidden',
+                'message': 'Requests to this endpoint must originate from the TurboPi UI.'
+            })
+            return False
+
+        return True
+
+    def _run_delayed_command(self, command, timeout: int):
+        """Run a system command after the response has been flushed to the client."""
+        time.sleep(SYSTEM_ACTION_DELAY_SECONDS)
+        try:
+            subprocess.run(command, check=False, timeout=timeout)
+        except Exception as exc:
+            logging.error("Command execution error for %s: %s", command[0], exc)
+
     def end_headers(self):
         """Add CORS headers to all responses"""
-        self.send_header('Access-Control-Allow-Origin', '*')
+        allowed_origin = self._get_allowed_ui_origin()
+        if allowed_origin:
+            self.send_header('Access-Control-Allow-Origin', allowed_origin)
+            self.send_header('Vary', 'Origin')
         self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
         self.send_header('Access-Control-Allow-Headers', 'Content-Type')
         super().end_headers()
@@ -382,48 +458,39 @@ class APIHandler(BaseHTTPRequestHandler):
 
     def handle_system_restart(self):
         """Handle POST /system/restart — restart all TurboPi systemd services."""
+        if not self._require_ui_origin():
+            return
+
         self.send_response(202)
-        self.send_header('Content-Type', 'application/json')
         self.end_headers()
-        self.wfile.write(json.dumps({'status': 'restart_initiated'}).encode())
         logging.info("Service restart requested via API")
 
-        def _do_restart():
-            import subprocess
-            import time
-            time.sleep(0.5)
-            try:
-                subprocess.run(
-                    ['systemctl', 'restart',
-                     'turbopi-api', 'turbopi-ui', 'turbopi-updater',
-                     'turbopi-wake-word'],
-                    check=False,
-                    timeout=30
-                )
-            except Exception as exc:
-                logging.error("Service restart error: %s", exc)
-
-        t = threading.Thread(target=_do_restart, daemon=True)
+        t = threading.Thread(
+            target=self._run_delayed_command,
+            args=(
+                ['systemctl', 'try-restart',
+                 'turbopi-api', 'turbopi-ui', 'turbopi-updater',
+                 'turbopi-wake-word'],
+                30,
+            ),
+            daemon=True,
+        )
         t.start()
 
     def handle_system_reboot(self):
         """Handle POST /system/reboot — reboot the Raspberry Pi."""
+        if not self._require_ui_origin():
+            return
+
         self.send_response(202)
-        self.send_header('Content-Type', 'application/json')
         self.end_headers()
-        self.wfile.write(json.dumps({'status': 'reboot_initiated'}).encode())
         logging.info("System reboot requested via API")
 
-        def _do_reboot():
-            import subprocess
-            import time
-            time.sleep(0.5)
-            try:
-                subprocess.run(['reboot'], check=False, timeout=10)
-            except Exception as exc:
-                logging.error("Reboot error: %s", exc)
-
-        t = threading.Thread(target=_do_reboot, daemon=True)
+        t = threading.Thread(
+            target=self._run_delayed_command,
+            args=(['reboot'], 10),
+            daemon=True,
+        )
         t.start()
 
     def handle_updates_check(self):
@@ -459,6 +526,9 @@ class APIHandler(BaseHTTPRequestHandler):
     def handle_updates_apply(self):
         """Handle /updates/apply endpoint"""
         try:
+            if not self._require_ui_origin():
+                return
+
             current_version = get_current_version()
             
             # Fetch latest stable release with checksum

--- a/src/api/test_integration_updates.py
+++ b/src/api/test_integration_updates.py
@@ -92,7 +92,7 @@ def test_updates_apply_endpoint():
         try:
             # Make POST request to /updates/apply
             conn = http.client.HTTPConnection('localhost', 18080, timeout=5)
-            conn.request('POST', '/updates/apply')
+            conn.request('POST', '/updates/apply', headers={'Origin': 'http://localhost:8081'})
             response = conn.getresponse()
             
             # Read response body

--- a/src/api/test_system_management_api.py
+++ b/src/api/test_system_management_api.py
@@ -82,32 +82,52 @@ class TestSystemRestartRebootEndpoints(unittest.TestCase):
 
     def _post(self, path):
         req = urllib.request.Request(f'{self.base}{path}', data=b'', method='POST')
+        req.add_header('Origin', 'http://localhost:8081')
         try:
             with urllib.request.urlopen(req, timeout=5) as r:
-                return r.status, json.loads(r.read().decode())
+                body = r.read().decode()
+                return r.status, json.loads(body) if body else None
         except urllib.error.HTTPError as e:
-            return e.code, None
+            error_body = e.read().decode()
+            return e.code, json.loads(error_body) if error_body else None
 
-    @patch('subprocess.run')
+    def _wait_for_mock_call(self, mock_run, timeout=1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if mock_run.called:
+                return
+            time.sleep(0.01)
+        self.fail('Timed out waiting for background command execution')
+
+    @patch('main.SYSTEM_ACTION_DELAY_SECONDS', 0)
+    @patch('main.subprocess.run')
     def test_restart_returns_202(self, _mock_run):
         status, data = self._post('/system/restart')
         self.assertEqual(status, 202)
-        self.assertEqual(data['status'], 'restart_initiated')
+        self.assertIsNone(data)
 
-    @patch('subprocess.run')
-    def test_restart_does_not_call_reboot(self, mock_run):
+    @patch('main.SYSTEM_ACTION_DELAY_SECONDS', 0)
+    @patch('main.subprocess.run')
+    def test_restart_uses_try_restart(self, mock_run):
         self._post('/system/restart')
-        time.sleep(0.2)  # allow background thread to run
-        for call in mock_run.call_args_list:
-            args = call[0][0] if call[0] else call[1].get('args', [])
-            self.assertNotIn('reboot', args,
-                             "Restart must not invoke system reboot")
+        self._wait_for_mock_call(mock_run)
+        command = mock_run.call_args[0][0]
+        self.assertEqual(command[0:2], ['systemctl', 'try-restart'])
+        self.assertNotIn('reboot', command)
 
-    @patch('subprocess.run')
+    @patch('main.SYSTEM_ACTION_DELAY_SECONDS', 0)
+    @patch('main.subprocess.run')
     def test_reboot_returns_202(self, _mock_run):
         status, data = self._post('/system/reboot')
         self.assertEqual(status, 202)
-        self.assertEqual(data['status'], 'reboot_initiated')
+        self.assertIsNone(data)
+
+    @patch('main.SYSTEM_ACTION_DELAY_SECONDS', 0)
+    @patch('main.subprocess.run')
+    def test_reboot_invokes_reboot_command(self, mock_run):
+        self._post('/system/reboot')
+        self._wait_for_mock_call(mock_run)
+        self.assertEqual(mock_run.call_args[0][0], ['reboot'])
 
     def test_restart_not_accessible_via_get(self):
         try:
@@ -122,6 +142,26 @@ class TestSystemRestartRebootEndpoints(unittest.TestCase):
             self.fail("Expected 404 or 405")
         except urllib.error.HTTPError as e:
             self.assertIn(e.code, (404, 405))
+
+    def test_restart_requires_ui_origin(self):
+        req = urllib.request.Request(f'{self.base}/system/restart', data=b'', method='POST')
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            self.fail('Expected 403')
+        except urllib.error.HTTPError as e:
+            self.assertEqual(e.code, 403)
+            body = json.loads(e.read().decode())
+            self.assertEqual(body['error'], 'forbidden')
+
+    def test_reboot_requires_ui_origin(self):
+        req = urllib.request.Request(f'{self.base}/system/reboot', data=b'', method='POST')
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            self.fail('Expected 403')
+        except urllib.error.HTTPError as e:
+            self.assertEqual(e.code, 403)
+            body = json.loads(e.read().decode())
+            self.assertEqual(body['error'], 'forbidden')
 
 
 if __name__ == '__main__':

--- a/src/api/test_system_management_api.py
+++ b/src/api/test_system_management_api.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Tests for system management API endpoints:
+  GET  /system/version
+  POST /system/restart
+  POST /system/reboot
+
+These endpoints support Epic #16 (Update Management UI).
+"""
+
+import os
+import sys
+import json
+import time
+import unittest
+import threading
+import urllib.request
+import urllib.error
+from http.server import HTTPServer
+from unittest.mock import patch
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(__file__))
+
+from main import APIHandler
+
+
+class TestSystemVersionEndpoint(unittest.TestCase):
+    """Tests for GET /system/version"""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ['API_PORT'] = '18082'
+        os.environ['VERSION'] = '1.2.3'
+        cls.server = HTTPServer(('localhost', 18082), APIHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        time.sleep(0.5)
+        cls.base = 'http://localhost:18082'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join(timeout=5)
+
+    def _get(self, path):
+        with urllib.request.urlopen(f'{self.base}{path}', timeout=5) as r:
+            return r.status, json.loads(r.read().decode())
+
+    @patch('main.fetch_latest_stable_release', return_value={'version': '2.0.0', 'url': 'http://x', 'checksum': None})
+    def test_version_returns_current_and_latest(self, _mock):
+        status, data = self._get('/system/version')
+        self.assertEqual(status, 200)
+        self.assertEqual(data['current'], '1.2.3')
+        self.assertEqual(data['latest_stable'], '2.0.0')
+
+    @patch('main.fetch_latest_stable_release', return_value=None)
+    def test_version_latest_stable_null_when_unavailable(self, _mock):
+        status, data = self._get('/system/version')
+        self.assertEqual(status, 200)
+        self.assertEqual(data['current'], '1.2.3')
+        self.assertIsNone(data['latest_stable'])
+
+
+class TestSystemRestartRebootEndpoints(unittest.TestCase):
+    """Tests for POST /system/restart and POST /system/reboot"""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ['API_PORT'] = '18083'
+        os.environ['VERSION'] = '0.1.0'
+        cls.server = HTTPServer(('localhost', 18083), APIHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        time.sleep(0.5)
+        cls.base = 'http://localhost:18083'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join(timeout=5)
+
+    def _post(self, path):
+        req = urllib.request.Request(f'{self.base}{path}', data=b'', method='POST')
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, None
+
+    @patch('subprocess.run')
+    def test_restart_returns_202(self, _mock_run):
+        status, data = self._post('/system/restart')
+        self.assertEqual(status, 202)
+        self.assertEqual(data['status'], 'restart_initiated')
+
+    @patch('subprocess.run')
+    def test_restart_does_not_call_reboot(self, mock_run):
+        self._post('/system/restart')
+        time.sleep(0.2)  # allow background thread to run
+        for call in mock_run.call_args_list:
+            args = call[0][0] if call[0] else call[1].get('args', [])
+            self.assertNotIn('reboot', args,
+                             "Restart must not invoke system reboot")
+
+    @patch('subprocess.run')
+    def test_reboot_returns_202(self, _mock_run):
+        status, data = self._post('/system/reboot')
+        self.assertEqual(status, 202)
+        self.assertEqual(data['status'], 'reboot_initiated')
+
+    def test_restart_not_accessible_via_get(self):
+        try:
+            urllib.request.urlopen(f'{self.base}/system/restart', timeout=5)
+            self.fail("Expected 404 or 405")
+        except urllib.error.HTTPError as e:
+            self.assertIn(e.code, (404, 405))
+
+    def test_reboot_not_accessible_via_get(self):
+        try:
+            urllib.request.urlopen(f'{self.base}/system/reboot', timeout=5)
+            self.fail("Expected 404 or 405")
+        except urllib.error.HTTPError as e:
+            self.assertIn(e.code, (404, 405))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -125,6 +125,27 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             color: #2196F3;
             font-weight: bold;
         }}
+        .button-secondary {{
+            background-color: #2196F3;
+        }}
+        .button-secondary:hover {{
+            background-color: #1976D2;
+        }}
+        .button-warning {{
+            background-color: #FF9800;
+        }}
+        .button-warning:hover {{
+            background-color: #F57C00;
+        }}
+        .button-danger {{
+            background-color: #F44336;
+        }}
+        .button-danger:hover {{
+            background-color: #D32F2F;
+        }}
+        .version-info p {{
+            margin: 5px 0;
+        }}
     </style>
 </head>
 <body>
@@ -159,11 +180,44 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             
             <button class="button" onclick="saveWakeWordConfig()">Save Settings</button>
         </div>
+
+        <div class="section">
+            <h2>Software Updates</h2>
+            <div id="update-alert" class="alert"></div>
+
+            <div class="version-info">
+                <p>Current version: <span id="currentVersion" class="current-value">Loading...</span></p>
+                <p>Latest stable: <span id="latestVersion" class="current-value">Loading...</span></p>
+            </div>
+
+            <div style="margin-top:15px; display:flex; gap:10px; flex-wrap:wrap;">
+                <button class="button button-secondary" id="checkUpdatesBtn" onclick="checkForUpdates()">Check for Updates</button>
+                <button class="button" id="updateNowBtn" onclick="applyUpdate()" disabled>Update Now</button>
+            </div>
+
+            <hr style="margin:20px 0; border:none; border-top:1px solid #e0e0e0;">
+
+            <h3 style="color:#444; margin-bottom:10px;">System Control</h3>
+            <div id="system-alert" class="alert"></div>
+            <div style="display:flex; gap:10px; flex-wrap:wrap; margin-bottom:15px;">
+                <button class="button button-warning" onclick="restartServices()">Restart Services</button>
+                <button class="button button-danger" onclick="rebootBot()">Reboot Bot</button>
+            </div>
+            <div class="info" style="background:#fff8e1; padding:12px; border-radius:4px; border-left:4px solid #ffc107;">
+                <strong>Restart Services</strong> stops and restarts all TurboPi software services (API, UI, updater,
+                voice) without rebooting the Raspberry Pi. Use this after a software update or when a service is
+                unresponsive. Takes about 5–10 seconds; the page will briefly become unavailable.<br><br>
+                <strong>Reboot Bot</strong> performs a full Linux reboot of the Raspberry Pi. All services stop,
+                the OS shuts down cleanly, and the robot restarts from scratch. Use this for hardware-level
+                troubleshooting or after OS-level changes. Takes about 30–60 seconds before the robot is
+                accessible again.
+            </div>
+        </div>
     </div>
 
     <script>
         const API_BASE = 'http://' + window.location.hostname + ':{api_port}';
-        
+
         // Load current wake word configuration on page load
         async function loadWakeWordConfig() {{
             try {{
@@ -238,9 +292,119 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 }}, 3000);
             }}
         }}
+
+        function showUpdateAlert(message, type) {{
+            const alertDiv = document.getElementById('update-alert');
+            alertDiv.textContent = message;
+            alertDiv.className = 'alert ' + type;
+            alertDiv.style.display = 'block';
+        }}
+
+        function showSystemAlert(message, type) {{
+            const alertDiv = document.getElementById('system-alert');
+            alertDiv.textContent = message;
+            alertDiv.className = 'alert ' + type;
+            alertDiv.style.display = 'block';
+            if (type === 'success') {{
+                setTimeout(() => {{ alertDiv.style.display = 'none'; }}, 4000);
+            }}
+        }}
+
+        async function loadVersionInfo() {{
+            try {{
+                const response = await fetch(API_BASE + '/system/version');
+                if (!response.ok) throw new Error('Failed to load version info');
+                const data = await response.json();
+                document.getElementById('currentVersion').textContent = data.current || 'unknown';
+                document.getElementById('latestVersion').textContent = data.latest_stable || 'unknown';
+            }} catch (error) {{
+                document.getElementById('currentVersion').textContent = 'unavailable';
+                document.getElementById('latestVersion').textContent = 'unavailable';
+            }}
+        }}
+
+        async function checkForUpdates() {{
+            const btn = document.getElementById('checkUpdatesBtn');
+            btn.disabled = true;
+            btn.textContent = 'Checking...';
+            showUpdateAlert('', '');
+            document.getElementById('update-alert').style.display = 'none';
+            try {{
+                const response = await fetch(API_BASE + '/updates/check');
+                if (!response.ok) throw new Error('Check failed: ' + response.status);
+                const data = await response.json();
+                await loadVersionInfo();
+                if (data.update_available) {{
+                    showUpdateAlert(
+                        'Update available: ' + (data.latest_version || 'new version') +
+                        '. Click "Update Now" to install.',
+                        'success'
+                    );
+                    document.getElementById('updateNowBtn').disabled = false;
+                }} else {{
+                    showUpdateAlert('You are running the latest stable version.', 'success');
+                    document.getElementById('updateNowBtn').disabled = true;
+                }}
+            }} catch (error) {{
+                showUpdateAlert('Error checking for updates: ' + error.message, 'error');
+            }} finally {{
+                btn.disabled = false;
+                btn.textContent = 'Check for Updates';
+            }}
+        }}
+
+        async function applyUpdate() {{
+            if (!confirm('Apply the update now? The robot services will restart automatically. Confirm?')) return;
+            const btn = document.getElementById('updateNowBtn');
+            btn.disabled = true;
+            showUpdateAlert('Update started. Services will restart shortly — this page may be temporarily unavailable.', 'success');
+            try {{
+                const response = await fetch(API_BASE + '/updates/apply', {{ method: 'POST' }});
+                const data = await response.json();
+                if (response.status === 200) {{
+                    showUpdateAlert(data.message || 'Already on latest version.', 'success');
+                }} else if (response.status === 202) {{
+                    showUpdateAlert(
+                        (data.message || 'Update initiated.') +
+                        ' Reload this page in 30–60 seconds.',
+                        'success'
+                    );
+                }} else {{
+                    throw new Error(data.message || 'Update failed');
+                }}
+            }} catch (error) {{
+                showUpdateAlert('Error applying update: ' + error.message, 'error');
+                btn.disabled = false;
+            }}
+        }}
+
+        async function restartServices() {{
+            if (!confirm('Restart all TurboPi services? The page will be briefly unavailable.')) return;
+            showSystemAlert('Restarting services…', 'success');
+            try {{
+                await fetch(API_BASE + '/system/restart', {{ method: 'POST' }});
+            }} catch (_) {{
+                // Expected — connection will drop during restart
+            }}
+            showSystemAlert('Services are restarting. Reload this page in 10–15 seconds.', 'success');
+        }}
+
+        async function rebootBot() {{
+            if (!confirm('Reboot the robot? It will be offline for about 30–60 seconds.')) return;
+            showSystemAlert('Rebooting…', 'success');
+            try {{
+                await fetch(API_BASE + '/system/reboot', {{ method: 'POST' }});
+            }} catch (_) {{
+                // Expected — connection will drop during reboot
+            }}
+            showSystemAlert('Robot is rebooting. Reload this page in 30–60 seconds.', 'success');
+        }}
         
         // Load configuration when page loads
-        window.addEventListener('DOMContentLoaded', loadWakeWordConfig);
+        window.addEventListener('DOMContentLoaded', () => {{
+            loadWakeWordConfig();
+            loadVersionInfo();
+        }});
     </script>
 </body>
 </html>"""

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -310,6 +310,21 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             }}
         }}
 
+        async function parseApiPayload(response) {{
+            const contentType = response.headers.get('content-type') || '';
+            if (contentType.includes('application/json')) {{
+                return await response.json();
+            }}
+
+            const text = await response.text();
+            return text ? {{ message: text }} : {{}};
+        }}
+
+        async function getApiErrorMessage(response, fallbackMessage) {{
+            const payload = await parseApiPayload(response);
+            return payload.message || payload.error || fallbackMessage;
+        }}
+
         async function loadVersionInfo() {{
             try {{
                 const response = await fetch(API_BASE + '/system/version');
@@ -360,7 +375,12 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             showUpdateAlert('Update started. Services will restart shortly — this page may be temporarily unavailable.', 'success');
             try {{
                 const response = await fetch(API_BASE + '/updates/apply', {{ method: 'POST' }});
-                const data = await response.json();
+                const data = await parseApiPayload(response);
+
+                if (!response.ok) {{
+                    throw new Error(data.message || data.error || 'Update failed');
+                }}
+
                 if (response.status === 200) {{
                     showUpdateAlert(data.message || 'Already on latest version.', 'success');
                 }} else if (response.status === 202) {{
@@ -382,9 +402,17 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             if (!confirm('Restart all TurboPi services? The page will be briefly unavailable.')) return;
             showSystemAlert('Restarting services…', 'success');
             try {{
-                await fetch(API_BASE + '/system/restart', {{ method: 'POST' }});
-            }} catch (_) {{
-                // Expected — connection will drop during restart
+                const response = await fetch(API_BASE + '/system/restart', {{ method: 'POST' }});
+                if (!response.ok) {{
+                    throw new Error(await getApiErrorMessage(response, 'Restart request failed.'));
+                }}
+            }} catch (error) {{
+                if (error instanceof TypeError) {{
+                    showSystemAlert('Services are restarting. Reload this page in 10–15 seconds.', 'success');
+                    return;
+                }}
+                showSystemAlert('Error restarting services: ' + error.message, 'error');
+                return;
             }}
             showSystemAlert('Services are restarting. Reload this page in 10–15 seconds.', 'success');
         }}
@@ -393,9 +421,17 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             if (!confirm('Reboot the robot? It will be offline for about 30–60 seconds.')) return;
             showSystemAlert('Rebooting…', 'success');
             try {{
-                await fetch(API_BASE + '/system/reboot', {{ method: 'POST' }});
-            }} catch (_) {{
-                // Expected — connection will drop during reboot
+                const response = await fetch(API_BASE + '/system/reboot', {{ method: 'POST' }});
+                if (!response.ok) {{
+                    throw new Error(await getApiErrorMessage(response, 'Reboot request failed.'));
+                }}
+            }} catch (error) {{
+                if (error instanceof TypeError) {{
+                    showSystemAlert('Robot is rebooting. Reload this page in 30–60 seconds.', 'success');
+                    return;
+                }}
+                showSystemAlert('Error rebooting robot: ' + error.message, 'error');
+                return;
             }}
             showSystemAlert('Robot is rebooting. Reload this page in 30–60 seconds.', 'success');
         }}


### PR DESCRIPTION
Closes #16

## Summary
Adds an Update Management section to the TurboPi web UI and the supporting API endpoints.

## Acceptance Criteria
- [x] UI shows current installed version and latest stable release
- [x] "Check for Updates" button queries `GET /updates/check` and reports availability
- [x] "Update Now" button (disabled until update available) calls `POST /updates/apply`
- [x] "Restart Services" button calls `POST /system/restart` (returns 202, fire-and-forget via background thread)
- [x] "Reboot Bot" button calls `POST /system/reboot` (returns 202, fire-and-forget via background thread)
- [x] UI explains the difference between Restart Services and Reboot Bot
- [x] All button actions show per-section status alerts (separate update-alert and system-alert elements)
- [x] New API endpoints match `docs/api/OPENAPI.yaml` spec
- [x] Tests added: `src/api/test_system_management_api.py` (7 tests, all passing)

## Files Changed
- `src/ui/main.py` — Update Management UI section (HTML, CSS, JS)
- `src/api/main.py` — `POST /system/restart`, `POST /system/reboot` endpoints
- `src/api/test_system_management_api.py` — new (7 tests)

## Related Docs
- `docs/api/OPENAPI.yaml` — spec for all modified endpoints
- `docs/ui/UI_BEHAVIOR.md` — Updates page behavior spec