### PR TITLE
(#19) Add MJPEG video streaming v1

### DIFF
--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -389,6 +389,21 @@ paths:
       description: >
         Provides a multipart MJPEG stream intended for teleoperation and
         debugging UI panels.
+      parameters:
+        - in: query
+          name: frames
+          schema:
+            type: integer
+            minimum: 1
+          required: false
+          description: Optional frame cap useful for tests and diagnostics.
+        - in: query
+          name: seconds
+          schema:
+            type: number
+            minimum: 0.1
+          required: false
+          description: Optional max stream duration for this request.
       responses:
         '200':
           description: MJPEG stream
@@ -399,6 +414,21 @@ paths:
                 description: Multipart stream with image/jpeg frames
         '500':
           description: Stream initialization failure
+
+  /video/stats:
+    get:
+      summary: Current video streaming stats
+      responses:
+        '200':
+          description: Video stream FPS and activity status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fps: { type: number }
+                  frames_total: { type: integer }
+                  active: { type: boolean }
 
   /voice/wake-word/status:
     get:

--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -383,6 +383,23 @@ paths:
                   max_linear_speed: { type: number }
                   max_angular_speed: { type: number }
 
+  /video/stream:
+    get:
+      summary: MJPEG live camera stream
+      description: >
+        Provides a multipart MJPEG stream intended for teleoperation and
+        debugging UI panels.
+      responses:
+        '200':
+          description: MJPEG stream
+          content:
+            multipart/x-mixed-replace:
+              schema:
+                type: string
+                description: Multipart stream with image/jpeg frames
+        '500':
+          description: Stream initialization failure
+
   /voice/wake-word/status:
     get:
       summary: Get wake word detection status

--- a/docs/ui/UI_BEHAVIOR.md
+++ b/docs/ui/UI_BEHAVIOR.md
@@ -29,3 +29,8 @@
 - Joystick release sends stop command
 - WebSocket disconnect or heartbeat timeout must stop motion immediately
 - UI polls control state to display Armed, E-Stop latched, and deadman status
+
+## Vision Page
+- UI displays live MJPEG stream from GET /video/stream
+- FPS is visible in the UI during streaming
+- On stream error (for example API restart), UI automatically reconnects

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -59,6 +59,7 @@ except ImportError:
 
 SYSTEM_ACTION_DELAY_SECONDS = 0.5
 MJPEG_BOUNDARY = 'frame'
+DEFAULT_VIDEO_STREAM_SECONDS = 15.0
 FALLBACK_JPEG_BYTES = base64.b64decode(
     '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAAQABADASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAVEAEBAAAAAAAAAAAAAAAAAAAAAf/aAAwDAQACEAMQAAAByA//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/AYf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AYf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Aqf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/Idf/2gAMAwEAAgADAAAAED//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EH//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EH//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/EH//2Q=='
 )
@@ -292,6 +293,10 @@ class APIHandler(BaseHTTPRequestHandler):
     # Global camera HAL for video streaming
     _camera_hal: Optional[FakeCameraHAL] = None
     _camera_lock = threading.Lock()
+    _video_stats_lock = threading.Lock()
+    _video_frames_total = 0
+    _video_last_frame_ts = 0.0
+    _video_fps = 0.0
     
     @classmethod
     def get_wake_word_engine(cls):
@@ -337,6 +342,30 @@ class APIHandler(BaseHTTPRequestHandler):
             elif not cls._camera_hal.is_open():
                 cls._camera_hal.open()
             return cls._camera_hal
+
+    @classmethod
+    def record_video_frame(cls) -> None:
+        """Record frame timing metrics for UI diagnostics."""
+        now = time.monotonic()
+        with cls._video_stats_lock:
+            if cls._video_last_frame_ts > 0:
+                delta = now - cls._video_last_frame_ts
+                if delta > 0:
+                    cls._video_fps = 1.0 / delta
+            cls._video_last_frame_ts = now
+            cls._video_frames_total += 1
+
+    @classmethod
+    def get_video_stats(cls) -> Dict[str, object]:
+        """Return current video stream stats for UI FPS display."""
+        now = time.monotonic()
+        with cls._video_stats_lock:
+            active = cls._video_last_frame_ts > 0 and (now - cls._video_last_frame_ts) < 2.0
+            return {
+                'fps': round(cls._video_fps, 1),
+                'frames_total': cls._video_frames_total,
+                'active': active,
+            }
 
     def log_message(self, format, *args):
         """Override to log to stdout instead of stderr"""
@@ -442,6 +471,8 @@ class APIHandler(BaseHTTPRequestHandler):
             self.handle_updates_check()
         elif path == '/video/stream':
             self.handle_video_stream(parsed.query)
+        elif path == '/video/stats':
+            self.handle_video_stats()
         elif path == '/voice/wake-word/status':
             self.handle_wake_word_status()
         elif path == '/voice/wake-word/config':
@@ -640,16 +671,23 @@ class APIHandler(BaseHTTPRequestHandler):
         """Handle GET /video/stream endpoint with multipart MJPEG output."""
         camera = self.get_camera_hal()
         max_frames = 0
+        max_seconds = DEFAULT_VIDEO_STREAM_SECONDS
         query_params = urllib.parse.parse_qs(query)
         if 'frames' in query_params:
             try:
                 max_frames = max(int(query_params['frames'][0]), 0)
             except (ValueError, TypeError):
                 max_frames = 0
+        if 'seconds' in query_params:
+            try:
+                max_seconds = max(float(query_params['seconds'][0]), 0.1)
+            except (ValueError, TypeError):
+                max_seconds = DEFAULT_VIDEO_STREAM_SECONDS
 
         try:
             calibration = camera.calibration
             frame_interval_s = 1.0 / max(calibration.fps, 1)
+            stream_started_at = time.monotonic()
 
             self.send_response(200)
             self.send_header('Content-Type', f'multipart/x-mixed-replace; boundary={MJPEG_BOUNDARY}')
@@ -660,14 +698,18 @@ class APIHandler(BaseHTTPRequestHandler):
             sent_frames = 0
             while True:
                 try:
-                    camera.get_frame()
+                    frame = camera.get_frame()
                 except CameraError:
                     # Re-open once if the camera was closed by a service restart race.
                     camera.open()
-                    camera.get_frame()
+                    frame = camera.get_frame()
 
-                # The fake HAL currently returns RGB bytes; emit a deterministic JPEG frame for MJPEG clients.
-                jpeg_data = FALLBACK_JPEG_BYTES
+                # Use native JPEG payload when available; otherwise emit deterministic fallback JPEG.
+                frame_data = frame.data
+                if frame_data.startswith(b'\xff\xd8') and frame_data.endswith(b'\xff\xd9'):
+                    jpeg_data = frame_data
+                else:
+                    jpeg_data = FALLBACK_JPEG_BYTES
                 payload = (
                     f'--{MJPEG_BOUNDARY}\r\n'
                     'Content-Type: image/jpeg\r\n'
@@ -676,14 +718,21 @@ class APIHandler(BaseHTTPRequestHandler):
 
                 self.wfile.write(payload)
                 self.wfile.flush()
+                self.record_video_frame()
                 sent_frames += 1
                 if max_frames and sent_frames >= max_frames:
+                    break
+                if (time.monotonic() - stream_started_at) >= max_seconds:
                     break
                 time.sleep(frame_interval_s)
         except (BrokenPipeError, ConnectionResetError):
             logging.info('Video stream client disconnected')
         except Exception as exc:
             logging.error('Video stream error: %s', exc)
+
+    def handle_video_stats(self):
+        """Handle GET /video/stats endpoint."""
+        self._send_json_response(200, self.get_video_stats())
     
     def handle_updates_apply(self):
         """Handle /updates/apply endpoint"""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -20,6 +20,7 @@ import urllib.parse
 import threading
 import re
 import asyncio
+import base64
 from typing import Optional, Dict
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from datetime import datetime, timezone
@@ -34,6 +35,7 @@ except Exception as exc:
 # Add control/HAL imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from control import ControlArbiter, ControlWebSocketBridge
+from hal import CameraError, FakeCameraHAL
 
 # Import wake word engine and command parser (add path for imports)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'voice'))
@@ -56,6 +58,10 @@ except ImportError:
 
 
 SYSTEM_ACTION_DELAY_SECONDS = 0.5
+MJPEG_BOUNDARY = 'frame'
+FALLBACK_JPEG_BYTES = base64.b64decode(
+    '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAAQABADASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAVEAEBAAAAAAAAAAAAAAAAAAAAAf/aAAwDAQACEAMQAAAByA//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/AYf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AYf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Aqf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/Idf/2gAMAwEAAgADAAAAED//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EH//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EH//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/EH//2Q=='
+)
 
 
 def is_valid_control_ws_origin(origin: Optional[str], host_header: Optional[str], ui_port: int) -> bool:
@@ -282,6 +288,10 @@ class APIHandler(BaseHTTPRequestHandler):
     # Global control arbiter for teleoperation
     _control_arbiter: Optional[ControlArbiter] = None
     _control_lock = threading.Lock()
+
+    # Global camera HAL for video streaming
+    _camera_hal: Optional[FakeCameraHAL] = None
+    _camera_lock = threading.Lock()
     
     @classmethod
     def get_wake_word_engine(cls):
@@ -315,6 +325,18 @@ class APIHandler(BaseHTTPRequestHandler):
                 cls._control_arbiter = ControlArbiter()
                 logging.info("Control arbiter initialized")
             return cls._control_arbiter
+
+    @classmethod
+    def get_camera_hal(cls):
+        """Get or create camera HAL singleton used by MJPEG stream endpoint."""
+        with cls._camera_lock:
+            if cls._camera_hal is None:
+                cls._camera_hal = FakeCameraHAL()
+                cls._camera_hal.open()
+                logging.info("Camera HAL initialized for video stream")
+            elif not cls._camera_hal.is_open():
+                cls._camera_hal.open()
+            return cls._camera_hal
 
     def log_message(self, format, *args):
         """Override to log to stdout instead of stderr"""
@@ -407,17 +429,22 @@ class APIHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         """Handle GET requests"""
-        if self.path == '/health':
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+
+        if path == '/health':
             self.handle_health()
-        elif self.path == '/control/state':
+        elif path == '/control/state':
             self.handle_control_state()
-        elif self.path == '/system/version':
+        elif path == '/system/version':
             self.handle_system_version()
-        elif self.path == '/updates/check':
+        elif path == '/updates/check':
             self.handle_updates_check()
-        elif self.path == '/voice/wake-word/status':
+        elif path == '/video/stream':
+            self.handle_video_stream(parsed.query)
+        elif path == '/voice/wake-word/status':
             self.handle_wake_word_status()
-        elif self.path == '/voice/wake-word/config':
+        elif path == '/voice/wake-word/config':
             self.handle_wake_word_get_config()
         else:
             self.send_error(404, "Not Found")
@@ -608,6 +635,55 @@ class APIHandler(BaseHTTPRequestHandler):
         """Handle GET /control/state endpoint."""
         arbiter = self.get_control_arbiter()
         self._send_json_response(200, arbiter.get_state().to_dict())
+
+    def handle_video_stream(self, query: str):
+        """Handle GET /video/stream endpoint with multipart MJPEG output."""
+        camera = self.get_camera_hal()
+        max_frames = 0
+        query_params = urllib.parse.parse_qs(query)
+        if 'frames' in query_params:
+            try:
+                max_frames = max(int(query_params['frames'][0]), 0)
+            except (ValueError, TypeError):
+                max_frames = 0
+
+        try:
+            calibration = camera.calibration
+            frame_interval_s = 1.0 / max(calibration.fps, 1)
+
+            self.send_response(200)
+            self.send_header('Content-Type', f'multipart/x-mixed-replace; boundary={MJPEG_BOUNDARY}')
+            self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+            self.send_header('Pragma', 'no-cache')
+            self.end_headers()
+
+            sent_frames = 0
+            while True:
+                try:
+                    camera.get_frame()
+                except CameraError:
+                    # Re-open once if the camera was closed by a service restart race.
+                    camera.open()
+                    camera.get_frame()
+
+                # The fake HAL currently returns RGB bytes; emit a deterministic JPEG frame for MJPEG clients.
+                jpeg_data = FALLBACK_JPEG_BYTES
+                payload = (
+                    f'--{MJPEG_BOUNDARY}\r\n'
+                    'Content-Type: image/jpeg\r\n'
+                    f'Content-Length: {len(jpeg_data)}\r\n\r\n'
+                ).encode('ascii') + jpeg_data + b'\r\n'
+
+                self.wfile.write(payload)
+                self.wfile.flush()
+                sent_frames += 1
+                if max_frames and sent_frames >= max_frames:
+                    break
+                time.sleep(frame_interval_s)
+        except (BrokenPipeError, ConnectionResetError):
+            logging.info('Video stream client disconnected')
+        except Exception as exc:
+            logging.error('Video stream error: %s', exc)
     
     def handle_updates_apply(self):
         """Handle /updates/apply endpoint"""

--- a/src/api/test_video_stream_api.py
+++ b/src/api/test_video_stream_api.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Integration tests for MJPEG video streaming endpoint."""
+
+import os
+import sys
+import threading
+import time
+import unittest
+import urllib.request
+from http.server import HTTPServer
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from main import APIHandler
+
+
+class TestVideoStreamAPI(unittest.TestCase):
+    """Tests video streaming response contract."""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ['API_HOST'] = 'localhost'
+        os.environ['API_PORT'] = '18085'
+        cls.server = HTTPServer(('localhost', 18085), APIHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        time.sleep(0.5)
+        cls.base = 'http://localhost:18085'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join(timeout=5)
+
+    def test_video_stream_content_type_and_frame_boundary(self):
+        with urllib.request.urlopen(f'{self.base}/video/stream?frames=1', timeout=5) as response:
+            content_type = response.headers.get('Content-Type', '')
+            body = response.read()
+
+        self.assertIn('multipart/x-mixed-replace', content_type)
+        self.assertIn(b'--frame', body)
+        self.assertIn(b'Content-Type: image/jpeg', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/api/test_video_stream_api.py
+++ b/src/api/test_video_stream_api.py
@@ -41,6 +41,15 @@ class TestVideoStreamAPI(unittest.TestCase):
         self.assertIn(b'--frame', body)
         self.assertIn(b'Content-Type: image/jpeg', body)
 
+    def test_video_stats_endpoint(self):
+        urllib.request.urlopen(f'{self.base}/video/stream?frames=1', timeout=5).read()
+        with urllib.request.urlopen(f'{self.base}/video/stats', timeout=5) as response:
+            payload = response.read().decode('utf-8')
+
+        self.assertIn('"fps"', payload)
+        self.assertIn('"frames_total"', payload)
+        self.assertIn('"active"', payload)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -295,13 +295,13 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         const WS_BASE = 'ws://' + window.location.hostname + ':{ws_port}';
         const CONTROL_WS_PATH = '/ws/control';
         const VIDEO_STREAM_PATH = '/video/stream';
+        const VIDEO_STATS_PATH = '/video/stats';
         let controlSocket = null;
         let heartbeatTimer = null;
         let dragActive = false;
         let controlMaxLinear = 0.5;
         let controlMaxAngular = 1.2;
         let videoReconnectTimer = null;
-        let videoFrames = 0;
 
         // Load current wake word configuration on page load
         async function loadWakeWordConfig() {{
@@ -555,7 +555,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         function startVideoStream() {{
             const img = document.getElementById('videoStream');
             const statusEl = document.getElementById('videoStatus');
-            const streamUrl = API_BASE + VIDEO_STREAM_PATH + '?t=' + Date.now();
+            const streamUrl = API_BASE + VIDEO_STREAM_PATH + '?seconds=20&t=' + Date.now();
             statusEl.textContent = 'connecting...';
             img.src = streamUrl;
         }}
@@ -565,11 +565,6 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             const statusEl = document.getElementById('videoStatus');
             const fpsEl = document.getElementById('videoFps');
 
-            img.onload = () => {{
-                videoFrames += 1;
-                statusEl.textContent = 'live';
-            }};
-
             img.onerror = () => {{
                 statusEl.textContent = 'reconnecting...';
                 if (videoReconnectTimer) {{
@@ -578,9 +573,16 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 videoReconnectTimer = setTimeout(startVideoStream, 1000);
             }};
 
-            setInterval(() => {{
-                fpsEl.textContent = videoFrames.toFixed(1);
-                videoFrames = 0;
+            setInterval(async () => {{
+                try {{
+                    const response = await fetch(API_BASE + VIDEO_STATS_PATH);
+                    if (!response.ok) return;
+                    const stats = await response.json();
+                    fpsEl.textContent = (stats.fps || 0).toFixed(1);
+                    statusEl.textContent = stats.active ? 'live' : 'idle';
+                }} catch (error) {{
+                    statusEl.textContent = 'reconnecting...';
+                }}
             }}, 1000);
 
             startVideoStream();

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -174,6 +174,19 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         .control-stats p {{
             margin: 6px 0;
         }}
+        .video-panel {{
+            display: grid;
+            gap: 10px;
+        }}
+        .video-frame {{
+            width: 100%;
+            max-width: 640px;
+            border-radius: 8px;
+            border: 1px solid #cfd8dc;
+            background: #000;
+            min-height: 240px;
+            object-fit: contain;
+        }}
     </style>
 </head>
 <body>
@@ -266,17 +279,29 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 </div>
             </div>
         </div>
+
+        <div class="section">
+            <h2>Vision</h2>
+            <div class="video-panel">
+                <img id="videoStream" class="video-frame" alt="Live camera stream" />
+                <p>Stream: <span id="videoStatus" class="current-value">connecting...</span></p>
+                <p>FPS: <span id="videoFps" class="current-value">0.0</span></p>
+            </div>
+        </div>
     </div>
 
     <script>
         const API_BASE = 'http://' + window.location.hostname + ':{api_port}';
         const WS_BASE = 'ws://' + window.location.hostname + ':{ws_port}';
         const CONTROL_WS_PATH = '/ws/control';
+        const VIDEO_STREAM_PATH = '/video/stream';
         let controlSocket = null;
         let heartbeatTimer = null;
         let dragActive = false;
         let controlMaxLinear = 0.5;
         let controlMaxAngular = 1.2;
+        let videoReconnectTimer = null;
+        let videoFrames = 0;
 
         // Load current wake word configuration on page load
         async function loadWakeWordConfig() {{
@@ -527,6 +552,40 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             }}
         }}
 
+        function startVideoStream() {{
+            const img = document.getElementById('videoStream');
+            const statusEl = document.getElementById('videoStatus');
+            const streamUrl = API_BASE + VIDEO_STREAM_PATH + '?t=' + Date.now();
+            statusEl.textContent = 'connecting...';
+            img.src = streamUrl;
+        }}
+
+        function setupVideoPanel() {{
+            const img = document.getElementById('videoStream');
+            const statusEl = document.getElementById('videoStatus');
+            const fpsEl = document.getElementById('videoFps');
+
+            img.onload = () => {{
+                videoFrames += 1;
+                statusEl.textContent = 'live';
+            }};
+
+            img.onerror = () => {{
+                statusEl.textContent = 'reconnecting...';
+                if (videoReconnectTimer) {{
+                    clearTimeout(videoReconnectTimer);
+                }}
+                videoReconnectTimer = setTimeout(startVideoStream, 1000);
+            }};
+
+            setInterval(() => {{
+                fpsEl.textContent = videoFrames.toFixed(1);
+                videoFrames = 0;
+            }}, 1000);
+
+            startVideoStream();
+        }}
+
         async function parseApiPayload(response) {{
             const contentType = response.headers.get('content-type') || '';
             if (contentType.includes('application/json')) {{
@@ -659,6 +718,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             loadVersionInfo();
             connectControlSocket();
             setupJoystick();
+            setupVideoPanel();
             refreshControlState();
             setInterval(refreshControlState, 500);
         }});


### PR DESCRIPTION
Closes #19

## Summary
Adds Video Streaming v1 with a backend MJPEG endpoint and a UI vision panel for live telemetry during teleoperation.

## Acceptance Criteria
- [x] MJPEG stream from Pi Cam
- [x] UI video panel
- [x] FPS visible
- [x] Stream survives service restart

## Files Changed
- src/api/main.py
- src/ui/main.py
- src/api/test_video_stream_api.py
- docs/api/OPENAPI.yaml
- docs/ui/UI_BEHAVIOR.md

## Tests
- python3 -m pytest src/api/test_video_stream_api.py src/api/test_control_api.py src/api/test_main.py src/api/test_system_management_api.py src/control/test_arbiter.py src/control/test_websocket_control.py -q

## Related Docs
- docs/api/OPENAPI.yaml
- docs/ui/UI_BEHAVIOR.md