### PR TITLE
(#20) Add observability and diagnostics bundle

### DIFF
--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -25,6 +25,42 @@ paths:
                   cpu_temp: { type: number }
                   version: { type: string }
                   timestamp: { type: string, format: date-time }
+                  memory:
+                    type: object
+                    properties:
+                      total_mb: { type: number }
+                      used_mb: { type: number }
+                      available_mb: { type: number }
+                  disk:
+                    type: object
+                    properties:
+                      total_mb: { type: number }
+                      used_mb: { type: number }
+                      free_mb: { type: number }
+                  services:
+                    type: object
+                    properties:
+                      api: { type: string }
+                      ui: { type: string }
+                      updater: { type: string }
+                      wake_word: { type: string }
+
+  /diagnostics/bundle:
+    get:
+      summary: Download diagnostics bundle
+      description: >
+        Generates a downloadable diagnostics archive with redacted logs and
+        configuration suitable for support without SSH access.
+      responses:
+        '200':
+          description: gzipped tar diagnostics bundle
+          content:
+            application/gzip:
+              schema:
+                type: string
+                format: binary
+        '500':
+          description: Failed to generate diagnostics bundle
 
   /system/version:
     get:

--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -51,6 +51,8 @@ paths:
       description: >
         Generates a downloadable diagnostics archive with redacted logs and
         configuration suitable for support without SSH access.
+        Development prototype endpoint for trusted local-network use.
+        This endpoint currently relies on same-host UI origin checks.
       responses:
         '200':
           description: gzipped tar diagnostics bundle
@@ -59,6 +61,15 @@ paths:
               schema:
                 type: string
                 format: binary
+        '403':
+          description: Request origin is not allowed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "forbidden" }
+                  message: { type: string }
         '500':
           description: Failed to generate diagnostics bundle
 

--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -22,7 +22,7 @@ paths:
                 properties:
                   status: { type: string }
                   uptime: { type: number }
-                  cpu_temp: { type: number }
+                  cpu_temp: { type: number, nullable: true }
                   version: { type: string }
                   timestamp: { type: string, format: date-time }
                   memory:

--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -72,6 +72,13 @@ paths:
                   message: { type: string }
         '500':
           description: Failed to generate diagnostics bundle
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  message: { type: string }
 
   /system/version:
     get:

--- a/docs/ui/UI_BEHAVIOR.md
+++ b/docs/ui/UI_BEHAVIOR.md
@@ -34,3 +34,9 @@
 - UI displays live MJPEG stream from GET /video/stream
 - FPS is visible in the UI during streaming
 - On stream error (for example API restart), UI automatically reconnects
+
+## System Status Page
+- UI displays expanded health data from GET /health (uptime, temperature, memory, disk, services)
+- UI refreshes system status automatically while page is open
+- "Download Diagnostics Bundle" triggers GET /diagnostics/bundle
+- Diagnostics bundles must contain redacted logs/configuration data

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -21,6 +21,9 @@ import threading
 import re
 import asyncio
 import base64
+import io
+import tarfile
+import tempfile
 from typing import Optional, Dict
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from datetime import datetime, timezone
@@ -89,6 +92,145 @@ def get_current_version() -> str:
         Current version string from VERSION env var, defaults to '0.1.0-dev'
     """
     return os.environ.get('VERSION', '0.1.0-dev')
+
+
+def redact_secrets(text: str) -> str:
+    """Redact common secret patterns from logs/config text."""
+    patterns = [
+        (r'(OPENAI_API_KEY\s*=\s*)([^\s\n]+)', r'\1***REDACTED***'),
+        (r'(password\s*[=:]\s*)([^\s\n]+)', r'\1***REDACTED***'),
+        (r'(wpa_passphrase\s*=\s*)([^\s\n]+)', r'\1***REDACTED***'),
+        (r'(Authorization:\s*Bearer\s+)([^\s\n]+)', r'\1***REDACTED***'),
+        (r'(api[_-]?key\s*[=:]\s*)([^\s\n]+)', r'\1***REDACTED***'),
+        (r'("(?:password|token|api_key)"\s*:\s*")([^"]+)(")', r'\1***REDACTED***\3'),
+    ]
+    redacted = text
+    for pattern, replacement in patterns:
+        redacted = re.sub(pattern, replacement, redacted, flags=re.IGNORECASE)
+    return redacted
+
+
+def _safe_run(command, timeout: int = 3) -> str:
+    """Run system commands safely and return output text."""
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=False)
+        return (result.stdout or '').strip()
+    except Exception:
+        return ''
+
+
+def _service_state(service_name: str) -> str:
+    """Return systemd service state string for diagnostics."""
+    value = _safe_run(['systemctl', 'is-active', service_name], timeout=2)
+    return value or 'unknown'
+
+
+def _disk_usage(path: str = '/') -> Dict[str, float]:
+    """Return disk usage stats in MB for the provided mount path."""
+    try:
+        stat = os.statvfs(path)
+        total = (stat.f_blocks * stat.f_frsize) / (1024 * 1024)
+        free = (stat.f_bavail * stat.f_frsize) / (1024 * 1024)
+        used = total - free
+        return {
+            'total_mb': round(total, 1),
+            'used_mb': round(used, 1),
+            'free_mb': round(free, 1),
+        }
+    except Exception:
+        return {'total_mb': 0.0, 'used_mb': 0.0, 'free_mb': 0.0}
+
+
+def _memory_usage() -> Dict[str, float]:
+    """Return memory stats in MB parsed from /proc/meminfo when available."""
+    try:
+        with open('/proc/meminfo', 'r', encoding='utf-8') as handle:
+            content = handle.read()
+        total_match = re.search(r'^MemTotal:\s+(\d+)\s+kB$', content, flags=re.MULTILINE)
+        avail_match = re.search(r'^MemAvailable:\s+(\d+)\s+kB$', content, flags=re.MULTILINE)
+        if not total_match or not avail_match:
+            return {'total_mb': 0.0, 'used_mb': 0.0, 'available_mb': 0.0}
+        total = int(total_match.group(1)) / 1024.0
+        available = int(avail_match.group(1)) / 1024.0
+        used = total - available
+        return {
+            'total_mb': round(total, 1),
+            'used_mb': round(used, 1),
+            'available_mb': round(available, 1),
+        }
+    except Exception:
+        return {'total_mb': 0.0, 'used_mb': 0.0, 'available_mb': 0.0}
+
+
+def build_health_snapshot() -> Dict[str, object]:
+    """Build expanded health payload for API and diagnostics bundle."""
+    uptime_seconds = 0.0
+    try:
+        with open('/proc/uptime', 'r', encoding='utf-8') as handle:
+            uptime_seconds = float(handle.readline().split()[0])
+    except Exception:
+        uptime_seconds = 0.0
+
+    cpu_temp = None
+    try:
+        with open('/sys/class/thermal/thermal_zone0/temp', 'r', encoding='utf-8') as handle:
+            cpu_temp = float(handle.read().strip()) / 1000.0
+    except Exception:
+        cpu_temp = None
+
+    return {
+        'status': 'ok',
+        'uptime': uptime_seconds,
+        'cpu_temp': cpu_temp,
+        'version': get_current_version(),
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'memory': _memory_usage(),
+        'disk': _disk_usage('/'),
+        'services': {
+            'api': _service_state('turbopi-api'),
+            'ui': _service_state('turbopi-ui'),
+            'updater': _service_state('turbopi-updater'),
+            'wake_word': _service_state('turbopi-wake-word'),
+        },
+    }
+
+
+def build_diagnostics_bundle() -> bytes:
+    """Create gzipped tar diagnostics bundle with redacted logs/config."""
+    health_snapshot = build_health_snapshot()
+    config_path = '/etc/turbopi/config.env'
+    config_raw = ''
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, 'r', encoding='utf-8') as handle:
+                config_raw = handle.read()
+        except Exception:
+            config_raw = ''
+
+    journal_output = _safe_run(
+        ['journalctl', '--no-pager', '-n', '300', '-u', 'turbopi-api', '-u', 'turbopi-ui', '-u', 'turbopi-updater'],
+        timeout=5,
+    )
+
+    files = {
+        'health.json': json.dumps(health_snapshot, indent=2),
+        'config.env.redacted': redact_secrets(config_raw),
+        'logs/systemd.log.redacted': redact_secrets(journal_output),
+        'meta.txt': 'TurboPi diagnostics bundle\nContains redacted support data.\n',
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for name, content in files.items():
+            abs_path = os.path.join(tmp_dir, name)
+            os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+            with open(abs_path, 'w', encoding='utf-8') as handle:
+                handle.write(content)
+
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode='w:gz') as tar_handle:
+            for name in files:
+                tar_handle.add(os.path.join(tmp_dir, name), arcname=name)
+        return buffer.getvalue()
 
 
 def normalize_version(version: str) -> tuple:
@@ -473,6 +615,8 @@ class APIHandler(BaseHTTPRequestHandler):
             self.handle_video_stream(parsed.query)
         elif path == '/video/stats':
             self.handle_video_stats()
+        elif path == '/diagnostics/bundle':
+            self.handle_diagnostics_bundle()
         elif path == '/voice/wake-word/status':
             self.handle_wake_word_status()
         elif path == '/voice/wake-word/config':
@@ -508,29 +652,7 @@ class APIHandler(BaseHTTPRequestHandler):
     def handle_health(self):
         """Handle /health endpoint"""
         try:
-            # Get system uptime
-            with open('/proc/uptime', 'r') as f:
-                uptime = float(f.readline().split()[0])
-
-            # Get CPU temperature (if available)
-            cpu_temp = None
-            try:
-                with open('/sys/class/thermal/thermal_zone0/temp', 'r') as f:
-                    cpu_temp = float(f.read().strip()) / 1000.0
-            except (FileNotFoundError, ValueError):
-                # CPU temperature not available on this system
-                pass
-
-            # Get version from environment or default
-            version = get_current_version()
-
-            health_data = {
-                'status': 'ok',
-                'uptime': uptime,
-                'cpu_temp': cpu_temp,
-                'version': version,
-                'timestamp': datetime.now(timezone.utc).isoformat()
-            }
+            health_data = build_health_snapshot()
 
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
@@ -541,6 +663,22 @@ class APIHandler(BaseHTTPRequestHandler):
             logging.error(f"Health endpoint error: {str(e)}")
             # Return generic error message to client
             self.send_error(500, "Internal Server Error: Unable to retrieve health status")
+
+    def handle_diagnostics_bundle(self):
+        """Handle GET /diagnostics/bundle endpoint."""
+        try:
+            payload = build_diagnostics_bundle()
+            timestamp = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+            filename = f'turbopi-diagnostics-{timestamp}.tar.gz'
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/gzip')
+            self.send_header('Content-Disposition', f'attachment; filename="{filename}"')
+            self.send_header('Cache-Control', 'no-store')
+            self.end_headers()
+            self.wfile.write(payload)
+        except Exception as exc:
+            logging.error('Failed to build diagnostics bundle: %s', exc)
+            self.send_error(500, 'Internal Server Error: Unable to generate diagnostics bundle')
 
     def handle_system_version(self):
         """Handle /system/version endpoint"""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -63,9 +63,13 @@ except ImportError:
 SYSTEM_ACTION_DELAY_SECONDS = 0.5
 MJPEG_BOUNDARY = 'frame'
 DEFAULT_VIDEO_STREAM_SECONDS = 15.0
+SERVICE_STATE_CACHE_TTL_SECONDS = 2.0
 FALLBACK_JPEG_BYTES = base64.b64decode(
     '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAAQABADASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAVEAEBAAAAAAAAAAAAAAAAAAAAAf/aAAwDAQACEAMQAAAByA//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/AYf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AYf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Aqf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/Idf/2gAMAwEAAgADAAAAED//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EH//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EH//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/EH//2Q=='
 )
+
+_SERVICE_STATE_CACHE = {'timestamp': 0.0, 'states': {}}
+_SERVICE_STATE_CACHE_LOCK = threading.Lock()
 
 
 def is_valid_control_ws_origin(origin: Optional[str], host_header: Optional[str], ui_port: int) -> bool:
@@ -123,6 +127,77 @@ def _service_state(service_name: str) -> str:
     """Return systemd service state string for diagnostics."""
     value = _safe_run(['systemctl', 'is-active', service_name], timeout=2)
     return value or 'unknown'
+
+
+def _cached_service_states() -> Dict[str, str]:
+    """Cache service state lookups briefly to avoid repeated shelling per /health poll."""
+    now = time.monotonic()
+    with _SERVICE_STATE_CACHE_LOCK:
+        age = now - _SERVICE_STATE_CACHE['timestamp']
+        if age <= SERVICE_STATE_CACHE_TTL_SECONDS and _SERVICE_STATE_CACHE['states']:
+            return dict(_SERVICE_STATE_CACHE['states'])
+
+        states = {
+            'api': _service_state('turbopi-api'),
+            'ui': _service_state('turbopi-ui'),
+            'updater': _service_state('turbopi-updater'),
+            'wake_word': _service_state('turbopi-wake-word'),
+        }
+        _SERVICE_STATE_CACHE['timestamp'] = now
+        _SERVICE_STATE_CACHE['states'] = states
+        return dict(states)
+
+
+def persist_wake_word_config(wake_word: Optional[str], enabled: Optional[bool]) -> bool:
+    """Persist wake-word settings to config.env while preserving unrelated keys."""
+    config_path = os.environ.get('CONFIG_ENV_PATH', '/etc/turbopi/config.env')
+    existing_lines = []
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, 'r', encoding='utf-8') as handle:
+                existing_lines = handle.readlines()
+        except Exception:
+            return False
+
+    replacements = {}
+    if wake_word is not None:
+        replacements['WAKE_WORD'] = wake_word
+    if enabled is not None:
+        replacements['WAKE_WORD_ENABLED'] = 'true' if enabled else 'false'
+
+    if not replacements:
+        return True
+
+    seen = set()
+    updated_lines = []
+    for line in existing_lines:
+        if '=' not in line or line.lstrip().startswith('#'):
+            updated_lines.append(line)
+            continue
+
+        key, _sep, _value = line.partition('=')
+        clean_key = key.strip()
+        if clean_key in replacements:
+            updated_lines.append(f'{clean_key}={replacements[clean_key]}\n')
+            seen.add(clean_key)
+        else:
+            updated_lines.append(line)
+
+    for key, value in replacements.items():
+        if key not in seen:
+            updated_lines.append(f'{key}={value}\n')
+
+    try:
+        os.makedirs(os.path.dirname(config_path), exist_ok=True)
+        tmp_path = f'{config_path}.tmp'
+        with open(tmp_path, 'w', encoding='utf-8') as handle:
+            handle.writelines(updated_lines)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, config_path)
+        return True
+    except Exception:
+        return False
 
 
 def _disk_usage(path: str = '/') -> Dict[str, float]:
@@ -186,19 +261,14 @@ def build_health_snapshot() -> Dict[str, object]:
         'timestamp': datetime.now(timezone.utc).isoformat(),
         'memory': _memory_usage(),
         'disk': _disk_usage('/'),
-        'services': {
-            'api': _service_state('turbopi-api'),
-            'ui': _service_state('turbopi-ui'),
-            'updater': _service_state('turbopi-updater'),
-            'wake_word': _service_state('turbopi-wake-word'),
-        },
+        'services': _cached_service_states(),
     }
 
 
 def build_diagnostics_bundle() -> bytes:
     """Create gzipped tar diagnostics bundle with redacted logs/config."""
     health_snapshot = build_health_snapshot()
-    config_path = '/etc/turbopi/config.env'
+    config_path = os.environ.get('DIAGNOSTICS_CONFIG_PATH', '/etc/turbopi/config.env')
     config_raw = ''
     if os.path.exists(config_path):
         try:
@@ -667,6 +737,8 @@ class APIHandler(BaseHTTPRequestHandler):
     def handle_diagnostics_bundle(self):
         """Handle GET /diagnostics/bundle endpoint."""
         try:
+            if not self._require_ui_origin():
+                return
             payload = build_diagnostics_bundle()
             timestamp = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
             filename = f'turbopi-diagnostics-{timestamp}.tar.gz'
@@ -1027,11 +1099,16 @@ class APIHandler(BaseHTTPRequestHandler):
             
             # Return updated configuration
             config = engine.get_config()
+            persisted = persist_wake_word_config(config.wake_word, config.enabled)
+            if not persisted:
+                logging.warning('Wake word configuration updated in runtime but failed to persist to config.env')
+
             response_data = {
                 'status': 'updated',
                 'wake_word': config.wake_word,
                 'enabled': config.enabled,
-                'timeout_seconds': config.timeout_seconds
+                'timeout_seconds': config.timeout_seconds,
+                'persisted': persisted,
             }
             
             self.send_response(200)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -196,7 +196,9 @@ def persist_wake_word_config(wake_word: Optional[str], enabled: Optional[bool]) 
             updated_lines.append(f'{key}={value}\n')
 
     try:
-        os.makedirs(os.path.dirname(config_path), exist_ok=True)
+        config_dir = os.path.dirname(config_path)
+        if config_dir:
+            os.makedirs(config_dir, exist_ok=True)
         tmp_path = f'{config_path}.tmp'
         with open(tmp_path, 'w', encoding='utf-8') as handle:
             handle.writelines(updated_lines)
@@ -758,7 +760,10 @@ class APIHandler(BaseHTTPRequestHandler):
             self.wfile.write(payload)
         except Exception as exc:
             logging.error('Failed to build diagnostics bundle: %s', exc)
-            self.send_error(500, 'Internal Server Error: Unable to generate diagnostics bundle')
+            self._send_json_response(500, {
+                'error': 'internal_server_error',
+                'message': 'Unable to generate diagnostics bundle',
+            })
 
     def handle_system_version(self):
         """Handle /system/version endpoint"""
@@ -1100,10 +1105,6 @@ class APIHandler(BaseHTTPRequestHandler):
             except ValueError as ve:
                 self.send_error(400, f"Invalid configuration: {str(ve)}")
                 return
-            
-            # TODO: Persist to /etc/turbopi/config.env for permanence across restarts
-            # Currently runtime-only per initial implementation scope
-            # Future enhancement: Update config file and reload on service restart
             
             # Return updated configuration
             config = engine.get_config()

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -137,11 +137,19 @@ def _cached_service_states() -> Dict[str, str]:
         if age <= SERVICE_STATE_CACHE_TTL_SECONDS and _SERVICE_STATE_CACHE['states']:
             return dict(_SERVICE_STATE_CACHE['states'])
 
+        # Query all required services in one systemctl invocation.
+        service_names = ['turbopi-api', 'turbopi-ui', 'turbopi-updater', 'turbopi-wake-word']
+        raw_states = _safe_run(['systemctl', 'is-active', *service_names], timeout=2)
+        lines = [line.strip() for line in raw_states.splitlines() if line.strip()]
+        mapped = ['unknown'] * len(service_names)
+        for idx in range(min(len(lines), len(service_names))):
+            mapped[idx] = lines[idx]
+
         states = {
-            'api': _service_state('turbopi-api'),
-            'ui': _service_state('turbopi-ui'),
-            'updater': _service_state('turbopi-updater'),
-            'wake_word': _service_state('turbopi-wake-word'),
+            'api': mapped[0],
+            'ui': mapped[1],
+            'updater': mapped[2],
+            'wake_word': mapped[3],
         }
         _SERVICE_STATE_CACHE['timestamp'] = now
         _SERVICE_STATE_CACHE['states'] = states

--- a/src/api/test_observability_api.py
+++ b/src/api/test_observability_api.py
@@ -95,21 +95,35 @@ class TestObservabilityAPI(unittest.TestCase):
             body = response.read()
 
         self.assertEqual(content_type, 'application/gzip')
-        bundle_path = os.path.join('/tmp', f'turbopi-diagnostics-{int(time.time())}.tar.gz')
-        with open(bundle_path, 'wb') as handle:
+        with tempfile.NamedTemporaryFile(suffix='.tar.gz') as handle:
             handle.write(body)
+            handle.flush()
 
-        with tarfile.open(bundle_path, 'r:gz') as archive:
-            names = archive.getnames()
-            self.assertIn('health.json', names)
-            self.assertIn('config.env.redacted', names)
-            self.assertIn('logs/systemd.log.redacted', names)
+            with tarfile.open(handle.name, 'r:gz') as archive:
+                names = archive.getnames()
+                self.assertIn('health.json', names)
+                self.assertIn('config.env.redacted', names)
+                self.assertIn('logs/systemd.log.redacted', names)
 
     def test_diagnostics_bundle_requires_ui_origin(self):
         with self.assertRaises(urllib.error.HTTPError) as context:
             urllib.request.urlopen(f'{self.base}/diagnostics/bundle', timeout=10)
 
         self.assertEqual(context.exception.code, 403)
+
+    @patch('main.build_diagnostics_bundle', side_effect=RuntimeError('boom'))
+    def test_diagnostics_bundle_500_returns_json_payload(self, _mock_bundle):
+        req = urllib.request.Request(f'{self.base}/diagnostics/bundle', method='GET')
+        req.add_header('Origin', 'http://localhost:8081')
+
+        with self.assertRaises(urllib.error.HTTPError) as context:
+            urllib.request.urlopen(req, timeout=10)
+
+        self.assertEqual(context.exception.code, 500)
+        self.assertEqual(context.exception.headers.get('Content-Type'), 'application/json')
+        payload = json.loads(context.exception.read().decode('utf-8'))
+        self.assertEqual(payload.get('error'), 'internal_server_error')
+        self.assertEqual(payload.get('message'), 'Unable to generate diagnostics bundle')
 
 
 if __name__ == '__main__':

--- a/src/api/test_observability_api.py
+++ b/src/api/test_observability_api.py
@@ -5,15 +5,18 @@ import json
 import os
 import sys
 import tarfile
+import tempfile
 import threading
 import time
 import unittest
 import urllib.request
+import urllib.error
 from http.server import HTTPServer
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from main import APIHandler, redact_secrets
+from main import APIHandler, build_diagnostics_bundle, redact_secrets
 
 
 class TestObservabilityHelpers(unittest.TestCase):
@@ -31,6 +34,30 @@ class TestObservabilityHelpers(unittest.TestCase):
         self.assertNotIn('my-pass', redacted)
         self.assertNotIn('abc123', redacted)
         self.assertIn('***REDACTED***', redacted)
+
+    @patch('main._safe_run', return_value='Authorization: Bearer topsecret-token')
+    def test_diagnostics_bundle_redacts_sensitive_material(self, _mock_safe_run):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = os.path.join(tmp_dir, 'config.env')
+            with open(config_path, 'w', encoding='utf-8') as handle:
+                handle.write('OPENAI_API_KEY=sk-live-secret\npassword=plain-pass\n')
+
+            with patch.dict(os.environ, {'DIAGNOSTICS_CONFIG_PATH': config_path}, clear=False):
+                bundle = build_diagnostics_bundle()
+
+            archive_path = os.path.join(tmp_dir, 'bundle.tar.gz')
+            with open(archive_path, 'wb') as handle:
+                handle.write(bundle)
+
+            with tarfile.open(archive_path, 'r:gz') as archive:
+                config_text = archive.extractfile('config.env.redacted').read().decode('utf-8')
+                logs_text = archive.extractfile('logs/systemd.log.redacted').read().decode('utf-8')
+
+            self.assertNotIn('sk-live-secret', config_text)
+            self.assertNotIn('plain-pass', config_text)
+            self.assertNotIn('topsecret-token', logs_text)
+            self.assertIn('***REDACTED***', config_text)
+            self.assertIn('***REDACTED***', logs_text)
 
 
 class TestObservabilityAPI(unittest.TestCase):
@@ -61,7 +88,9 @@ class TestObservabilityAPI(unittest.TestCase):
         self.assertIn('api', payload['services'])
 
     def test_diagnostics_bundle_is_downloadable_tar_gz(self):
-        with urllib.request.urlopen(f'{self.base}/diagnostics/bundle', timeout=10) as response:
+        req = urllib.request.Request(f'{self.base}/diagnostics/bundle', method='GET')
+        req.add_header('Origin', 'http://localhost:8081')
+        with urllib.request.urlopen(req, timeout=10) as response:
             content_type = response.headers.get('Content-Type', '')
             body = response.read()
 
@@ -75,6 +104,12 @@ class TestObservabilityAPI(unittest.TestCase):
             self.assertIn('health.json', names)
             self.assertIn('config.env.redacted', names)
             self.assertIn('logs/systemd.log.redacted', names)
+
+    def test_diagnostics_bundle_requires_ui_origin(self):
+        with self.assertRaises(urllib.error.HTTPError) as context:
+            urllib.request.urlopen(f'{self.base}/diagnostics/bundle', timeout=10)
+
+        self.assertEqual(context.exception.code, 403)
 
 
 if __name__ == '__main__':

--- a/src/api/test_observability_api.py
+++ b/src/api/test_observability_api.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Integration and unit tests for observability/diagnostics endpoints."""
+
+import json
+import os
+import sys
+import tarfile
+import threading
+import time
+import unittest
+import urllib.request
+from http.server import HTTPServer
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from main import APIHandler, redact_secrets
+
+
+class TestObservabilityHelpers(unittest.TestCase):
+    """Tests for secret redaction helper logic."""
+
+    def test_redact_secrets_masks_known_patterns(self):
+        raw = (
+            'OPENAI_API_KEY=sk-secret\n'
+            'password=my-pass\n'
+            'Authorization: Bearer abc123\n'
+            '{"api_key":"value","token":"value2"}\n'
+        )
+        redacted = redact_secrets(raw)
+        self.assertNotIn('sk-secret', redacted)
+        self.assertNotIn('my-pass', redacted)
+        self.assertNotIn('abc123', redacted)
+        self.assertIn('***REDACTED***', redacted)
+
+
+class TestObservabilityAPI(unittest.TestCase):
+    """Integration tests for expanded health and diagnostics bundle download."""
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ['API_HOST'] = 'localhost'
+        os.environ['API_PORT'] = '18086'
+        cls.server = HTTPServer(('localhost', 18086), APIHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        time.sleep(0.5)
+        cls.base = 'http://localhost:18086'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join(timeout=5)
+
+    def test_health_includes_expanded_fields(self):
+        with urllib.request.urlopen(f'{self.base}/health', timeout=5) as response:
+            payload = json.loads(response.read().decode('utf-8'))
+
+        self.assertIn('memory', payload)
+        self.assertIn('disk', payload)
+        self.assertIn('services', payload)
+        self.assertIn('api', payload['services'])
+
+    def test_diagnostics_bundle_is_downloadable_tar_gz(self):
+        with urllib.request.urlopen(f'{self.base}/diagnostics/bundle', timeout=10) as response:
+            content_type = response.headers.get('Content-Type', '')
+            body = response.read()
+
+        self.assertEqual(content_type, 'application/gzip')
+        bundle_path = os.path.join('/tmp', f'turbopi-diagnostics-{int(time.time())}.tar.gz')
+        with open(bundle_path, 'wb') as handle:
+            handle.write(body)
+
+        with tarfile.open(bundle_path, 'r:gz') as archive:
+            names = archive.getnames()
+            self.assertIn('health.json', names)
+            self.assertIn('config.env.redacted', names)
+            self.assertIn('logs/systemd.log.redacted', names)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/api/test_wake_word_api.py
+++ b/src/api/test_wake_word_api.py
@@ -12,6 +12,7 @@ import threading
 import time
 import urllib.request
 import urllib.error
+import tempfile
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -26,10 +27,16 @@ class TestWakeWordAPIEndpoints(unittest.TestCase):
     def setUpClass(cls):
         """Start test server"""
         # Set up test environment
+        cls._tmp_dir = tempfile.TemporaryDirectory()
+        cls._config_path = os.path.join(cls._tmp_dir.name, 'config.env')
+        with open(cls._config_path, 'w', encoding='utf-8') as handle:
+            handle.write('ROBOT_NAME=TestBot\n')
+
         os.environ['API_HOST'] = 'localhost'
         os.environ['API_PORT'] = '18080'
         os.environ['WAKE_WORD'] = 'TestWord'
         os.environ['WAKE_WORD_ENABLED'] = 'true'
+        os.environ['CONFIG_ENV_PATH'] = cls._config_path
         
         # Start server in background thread
         cls.server = HTTPServer(('localhost', 18080), APIHandler)
@@ -46,6 +53,7 @@ class TestWakeWordAPIEndpoints(unittest.TestCase):
         """Stop test server"""
         cls.server.shutdown()
         cls.server_thread.join(timeout=5)
+        cls._tmp_dir.cleanup()
     
     def _make_request(self, path, method='GET', data=None):
         """Helper to make HTTP requests"""
@@ -108,6 +116,7 @@ class TestWakeWordAPIEndpoints(unittest.TestCase):
         self.assertEqual(status_code, 200)
         self.assertEqual(data['status'], 'updated')
         self.assertEqual(data['wake_word'], 'NewWord')
+        self.assertTrue(data['persisted'])
         
         # Verify update persisted
         status_code, data = self._make_request('/voice/wake-word/config')
@@ -119,6 +128,22 @@ class TestWakeWordAPIEndpoints(unittest.TestCase):
             method='POST',
             data={'wake_word': 'TestWord'}
         )
+
+    def test_wake_word_update_persists_to_config_file(self):
+        status_code, data = self._make_request(
+            '/voice/wake-word/config',
+            method='POST',
+            data={'wake_word': 'PersistedWord', 'enabled': False}
+        )
+
+        self.assertEqual(status_code, 200)
+        self.assertTrue(data['persisted'])
+
+        with open(self.__class__._config_path, 'r', encoding='utf-8') as handle:
+            content = handle.read()
+
+        self.assertIn('WAKE_WORD=PersistedWord', content)
+        self.assertIn('WAKE_WORD_ENABLED=false', content)
     
     def test_wake_word_update_config_enabled(self):
         """Test POST /voice/wake-word/config to enable/disable"""

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -482,7 +482,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 document.body.appendChild(link);
                 link.click();
                 link.remove();
-                URL.revokeObjectURL(objectUrl);
+                setTimeout(() => URL.revokeObjectURL(objectUrl), 2000);
                 showDiagnosticsAlert('Diagnostics bundle downloaded.', 'success');
             }} catch (error) {{
                 showDiagnosticsAlert('Error downloading diagnostics bundle: ' + error.message, 'error');
@@ -808,7 +808,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             refreshControlState();
             refreshSystemStatus();
             setInterval(refreshControlState, 500);
-            setInterval(refreshSystemStatus, 2000);
+            setInterval(refreshSystemStatus, 5000);
         }});
     </script>
 </body>

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -256,7 +256,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         </div>
 
         <div class="section">
-            <h2>System Status</h2>
+            <h2>Health Telemetry</h2>
             <div id="diagnostics-alert" class="alert"></div>
             <p>Uptime: <span id="healthUptime" class="current-value">Loading...</span></p>
             <p>CPU Temp: <span id="healthCpuTemp" class="current-value">Loading...</span></p>

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -256,6 +256,22 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         </div>
 
         <div class="section">
+            <h2>System Status</h2>
+            <div id="diagnostics-alert" class="alert"></div>
+            <p>Uptime: <span id="healthUptime" class="current-value">Loading...</span></p>
+            <p>CPU Temp: <span id="healthCpuTemp" class="current-value">Loading...</span></p>
+            <p>Memory Used: <span id="healthMemory" class="current-value">Loading...</span></p>
+            <p>Disk Used: <span id="healthDisk" class="current-value">Loading...</span></p>
+            <p>API Service: <span id="healthApiService" class="current-value">Loading...</span></p>
+            <p>UI Service: <span id="healthUiService" class="current-value">Loading...</span></p>
+            <p>Updater Service: <span id="healthUpdaterService" class="current-value">Loading...</span></p>
+            <div style="margin-top:12px;">
+                <button class="button button-secondary" onclick="downloadDiagnosticsBundle()">Download Diagnostics Bundle</button>
+            </div>
+            <p class="info">Diagnostics bundles include redacted logs and configuration to support troubleshooting without SSH access.</p>
+        </div>
+
+        <div class="section">
             <h2>Teleoperation</h2>
             <div id="control-alert" class="alert"></div>
             <div style="display:flex; gap:10px; flex-wrap:wrap; margin-bottom:15px;">
@@ -402,6 +418,74 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             alertDiv.style.display = 'block';
             if (type === 'success') {{
                 setTimeout(() => {{ alertDiv.style.display = 'none'; }}, 2500);
+            }}
+        }}
+
+        function showDiagnosticsAlert(message, type) {{
+            const alertDiv = document.getElementById('diagnostics-alert');
+            alertDiv.textContent = message;
+            alertDiv.className = 'alert ' + type;
+            alertDiv.style.display = 'block';
+            if (type === 'success') {{
+                setTimeout(() => {{ alertDiv.style.display = 'none'; }}, 3000);
+            }}
+        }}
+
+        function formatUptime(seconds) {{
+            const total = Math.max(0, Math.floor(seconds || 0));
+            const hours = Math.floor(total / 3600);
+            const minutes = Math.floor((total % 3600) / 60);
+            const secs = total % 60;
+            return `${{hours}}h ${{minutes}}m ${{secs}}s`;
+        }}
+
+        async function refreshSystemStatus() {{
+            try {{
+                const response = await fetch(API_BASE + '/health');
+                if (!response.ok) return;
+                const data = await response.json();
+                document.getElementById('healthUptime').textContent = formatUptime(data.uptime);
+                document.getElementById('healthCpuTemp').textContent =
+                    typeof data.cpu_temp === 'number' ? `${{data.cpu_temp.toFixed(1)}} C` : 'n/a';
+
+                const memory = data.memory || {{}};
+                const disk = data.disk || {{}};
+                const services = data.services || {{}};
+
+                document.getElementById('healthMemory').textContent =
+                    (typeof memory.used_mb === 'number' && typeof memory.total_mb === 'number')
+                        ? `${{memory.used_mb.toFixed(0)}} / ${{memory.total_mb.toFixed(0)}} MB`
+                        : 'n/a';
+                document.getElementById('healthDisk').textContent =
+                    (typeof disk.used_mb === 'number' && typeof disk.total_mb === 'number')
+                        ? `${{disk.used_mb.toFixed(0)}} / ${{disk.total_mb.toFixed(0)}} MB`
+                        : 'n/a';
+                document.getElementById('healthApiService').textContent = services.api || 'unknown';
+                document.getElementById('healthUiService').textContent = services.ui || 'unknown';
+                document.getElementById('healthUpdaterService').textContent = services.updater || 'unknown';
+            }} catch (error) {{
+                // status refresh should stay best-effort
+            }}
+        }}
+
+        async function downloadDiagnosticsBundle() {{
+            try {{
+                const response = await fetch(API_BASE + '/diagnostics/bundle');
+                if (!response.ok) {{
+                    throw new Error('Failed to generate diagnostics bundle');
+                }}
+                const blob = await response.blob();
+                const objectUrl = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = objectUrl;
+                link.download = 'turbopi-diagnostics.tar.gz';
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                URL.revokeObjectURL(objectUrl);
+                showDiagnosticsAlert('Diagnostics bundle downloaded.', 'success');
+            }} catch (error) {{
+                showDiagnosticsAlert('Error downloading diagnostics bundle: ' + error.message, 'error');
             }}
         }}
 
@@ -722,7 +806,9 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             setupJoystick();
             setupVideoPanel();
             refreshControlState();
+            refreshSystemStatus();
             setInterval(refreshControlState, 500);
+            setInterval(refreshSystemStatus, 2000);
         }});
     </script>
 </body>


### PR DESCRIPTION
Closes #20

## Summary
Implements observability improvements for non-SSH support workflows:
- Expanded health telemetry
- System status UI panel
- Downloadable diagnostics bundle
- Secret redaction for exported support data

## Acceptance Criteria
- [x] Expanded /health endpoint
- [x] UI system status page
- [x] Downloadable diagnostics bundle
- [x] Secrets redacted from logs

## Files Changed
- src/api/main.py
- src/ui/main.py
- src/api/test_observability_api.py
- docs/api/OPENAPI.yaml
- docs/ui/UI_BEHAVIOR.md

## Tests
- python3 -m pytest src/api/test_observability_api.py src/api/test_video_stream_api.py src/api/test_control_api.py src/api/test_main.py src/api/test_system_management_api.py src/control/test_arbiter.py src/control/test_websocket_control.py -q

## Related Docs
- docs/api/OPENAPI.yaml
- docs/ui/UI_BEHAVIOR.md

## Hardening Follow-ups
- Added same-host origin protection for diagnostics bundle endpoint.
- Added short TTL caching and batched service status queries for /health.
- Persist wake-word config updates to config.env with persisted flag in response.
- Strengthened redaction and diagnostics access tests.
- Reduced System Status polling frequency and delayed object URL revocation in UI.
