### PR TITLE
(#21) Implement behavior framework and mode arbiter

### DIFF
--- a/docs/control/ARBITECTURE.md
+++ b/docs/control/ARBITECTURE.md
@@ -12,6 +12,11 @@
 - Voice command intents
 - Autonomy outputs
 
+## Behavior Interface
+- Autonomous behaviors emit `BehaviorCommand` envelopes with `behavior`, `linear_mps`, and `angular_rps`
+- Behaviors implement the `BehaviorProvider` contract and can yield `None` when no motion is requested
+- The arbiter is responsible for all clamping, safety checks, and final HAL writes
+
 ## Output
 - Velocity command to HAL
 
@@ -19,3 +24,5 @@
 - Only one output active per cycle
 - Invalid commands are dropped
 - Safety overrides never bypassed
+- Manual commands override autonomy for the configured manual override window
+- Autonomous commands are accepted only when the robot is armed and manual override is inactive

--- a/src/control/arbiter.py
+++ b/src/control/arbiter.py
@@ -4,8 +4,9 @@
 import os
 import time
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Optional
 
+from control.behavior import BehaviorCommand
 from hal.motor import MotorSafetyError, SimulatedMotorHAL, VelocityCommand
 
 
@@ -48,6 +49,7 @@ class ControlState:
     angular_rps: float
     max_linear_speed: float
     max_angular_speed: float
+    active_behavior: Optional[str]
 
     def to_dict(self) -> Dict[str, object]:
         """Serialize to JSON-friendly dictionary."""
@@ -60,6 +62,7 @@ class ControlState:
             'angular_rps': self.angular_rps,
             'max_linear_speed': self.max_linear_speed,
             'max_angular_speed': self.max_angular_speed,
+            'active_behavior': self.active_behavior,
         }
 
 
@@ -71,23 +74,39 @@ class ControlArbiter:
         self.max_linear_speed = max(_get_float('MAX_LINEAR_SPEED', 0.5), 0.01)
         self.max_angular_speed = max(_get_float('MAX_ANGULAR_SPEED', 1.2), 0.01)
         self.deadman_timeout_s = max(_get_int('DEADMAN_TIMEOUT_MS', 500), 1) / 1000.0
+        self.manual_override_timeout_s = max(
+            _get_int('MANUAL_OVERRIDE_TIMEOUT_MS', int(self.deadman_timeout_s * 1000)),
+            1,
+        ) / 1000.0
         self.estop_latched = False
         self.deadman_triggered = False
         self.last_heartbeat = time.monotonic()
+        self.last_manual_input = 0.0
         self.last_linear = 0.0
         self.last_angular = 0.0
+        self.autonomy_command: Optional[BehaviorCommand] = None
 
     def get_state(self) -> ControlState:
         """Return current control state for API/UI status updates."""
+        current_mode = 'disabled'
+        active_behavior = None
+        if self.motor_hal.get_state().armed:
+            if self._manual_has_priority() or self.autonomy_command is None:
+                current_mode = 'manual'
+            else:
+                current_mode = 'autonomous'
+                active_behavior = self.autonomy_command.behavior
+
         return ControlState(
             armed=self.motor_hal.get_state().armed,
             estop_latched=self.estop_latched,
-            mode='manual' if self.motor_hal.get_state().armed else 'disabled',
+            mode=current_mode,
             deadman_triggered=self.deadman_triggered,
             linear_mps=self.last_linear,
             angular_rps=self.last_angular,
             max_linear_speed=self.max_linear_speed,
             max_angular_speed=self.max_angular_speed,
+            active_behavior=active_behavior,
         )
 
     def arm(self) -> Dict[str, object]:
@@ -98,6 +117,7 @@ class ControlArbiter:
         self.motor_hal.arm()
         self.deadman_triggered = False
         self.last_heartbeat = time.monotonic()
+        self.last_manual_input = 0.0
         return {'status': 'armed'}
 
     def disarm(self) -> Dict[str, object]:
@@ -105,6 +125,7 @@ class ControlArbiter:
         self.motor_hal.disarm()
         self.last_linear = 0.0
         self.last_angular = 0.0
+        self.autonomy_command = None
         return {'status': 'disarmed'}
 
     def engage_estop(self) -> Dict[str, object]:
@@ -113,6 +134,7 @@ class ControlArbiter:
         self.motor_hal.disarm()
         self.last_linear = 0.0
         self.last_angular = 0.0
+        self.autonomy_command = None
         return {'status': 'estop_engaged'}
 
     def clear_estop(self) -> Dict[str, object]:
@@ -143,8 +165,43 @@ class ControlArbiter:
 
         self.last_linear = linear
         self.last_angular = angular
+        self.last_manual_input = time.monotonic()
         return {
             'status': 'ok',
+            'linear_mps': linear,
+            'angular_rps': angular,
+            'mode': 'manual',
+        }
+
+    def apply_autonomy(self, command: BehaviorCommand) -> Dict[str, object]:
+        """Apply autonomous behavior command unless manual control has priority."""
+        self._enforce_deadman()
+        self.heartbeat()
+        if self.estop_latched:
+            return {'status': 'blocked', 'message': 'E-Stop is latched'}
+        if not self.motor_hal.get_state().armed:
+            return {'status': 'ignored', 'message': 'Robot is disarmed'}
+        if self._manual_has_priority():
+            return {'status': 'overridden', 'message': 'manual_control_active'}
+
+        linear = _clamp(command.linear_mps, -self.max_linear_speed, self.max_linear_speed)
+        angular = _clamp(command.angular_rps, -self.max_angular_speed, self.max_angular_speed)
+        try:
+            self.motor_hal.set_velocity(VelocityCommand(linear_mps=linear, angular_rps=angular))
+        except MotorSafetyError as exc:
+            return {'status': 'error', 'message': str(exc)}
+
+        self.autonomy_command = BehaviorCommand(
+            behavior=command.behavior,
+            linear_mps=linear,
+            angular_rps=angular,
+        )
+        self.last_linear = linear
+        self.last_angular = angular
+        return {
+            'status': 'ok',
+            'mode': 'autonomous',
+            'behavior': command.behavior,
             'linear_mps': linear,
             'angular_rps': angular,
         }
@@ -154,6 +211,7 @@ class ControlArbiter:
         self.motor_hal.stop()
         self.last_linear = 0.0
         self.last_angular = 0.0
+        self.autonomy_command = None
         return {'status': 'stopped'}
 
     def on_disconnect(self) -> Dict[str, object]:
@@ -172,3 +230,9 @@ class ControlArbiter:
         if (time.monotonic() - self.last_heartbeat) > self.deadman_timeout_s:
             self.deadman_triggered = True
             self.stop()
+
+    def _manual_has_priority(self) -> bool:
+        """Manual commands always outrank autonomy for a short override window."""
+        if self.last_manual_input <= 0:
+            return False
+        return (time.monotonic() - self.last_manual_input) <= self.manual_override_timeout_s

--- a/src/control/behavior.py
+++ b/src/control/behavior.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Behavior interface and command envelope for autonomous control sources."""
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+
+@dataclass(frozen=True)
+class BehaviorCommand:
+    """A normalized autonomy command emitted by behavior modules."""
+
+    behavior: str
+    linear_mps: float
+    angular_rps: float
+
+
+class BehaviorProvider(Protocol):
+    """Contract for autonomous behaviors that can propose motion commands."""
+
+    def name(self) -> str:
+        """Return stable behavior identifier used for observability/UI."""
+
+    def next_command(self) -> Optional[BehaviorCommand]:
+        """Return the next command, or None when no motion should be requested."""

--- a/src/control/test_arbiter.py
+++ b/src/control/test_arbiter.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from control.arbiter import ControlArbiter
+from control.behavior import BehaviorCommand
 from hal.motor import SimulatedMotorHAL
 
 
@@ -21,6 +22,7 @@ class TestControlArbiter(unittest.TestCase):
             'MAX_LINEAR_SPEED': '0.5',
             'MAX_ANGULAR_SPEED': '1.2',
             'DEADMAN_TIMEOUT_MS': '50',
+            'MANUAL_OVERRIDE_TIMEOUT_MS': '120',
         }, clear=False)
         self.addCleanup(patcher.stop)
         patcher.start()
@@ -63,6 +65,42 @@ class TestControlArbiter(unittest.TestCase):
         self.arbiter.on_disconnect()
         self.assertEqual(self.arbiter.get_state().linear_mps, 0.0)
         self.assertTrue(self.arbiter.get_state().deadman_triggered)
+
+    def test_autonomy_command_applies_when_manual_inactive(self):
+        self.arbiter.arm()
+        result = self.arbiter.apply_autonomy(
+            BehaviorCommand(behavior='follow', linear_mps=0.2, angular_rps=-0.1)
+        )
+        self.assertEqual(result['status'], 'ok')
+        self.assertEqual(result['mode'], 'autonomous')
+
+        state = self.arbiter.get_state()
+        self.assertEqual(state.mode, 'autonomous')
+        self.assertEqual(state.active_behavior, 'follow')
+
+    def test_manual_control_overrides_autonomy(self):
+        self.arbiter.arm()
+        self.arbiter.apply_drive(0.1, 0.0)
+        result = self.arbiter.apply_autonomy(
+            BehaviorCommand(behavior='follow', linear_mps=0.2, angular_rps=0.2)
+        )
+        self.assertEqual(result['status'], 'overridden')
+
+        state = self.arbiter.get_state()
+        self.assertEqual(state.mode, 'manual')
+        self.assertIsNone(state.active_behavior)
+
+    def test_autonomy_allowed_after_manual_override_window(self):
+        self.arbiter.arm()
+        self.arbiter.apply_drive(0.1, 0.0)
+        time.sleep(0.13)
+        self.arbiter.heartbeat()
+
+        result = self.arbiter.apply_autonomy(
+            BehaviorCommand(behavior='follow', linear_mps=0.2, angular_rps=0.1)
+        )
+        self.assertEqual(result['status'], 'ok')
+        self.assertEqual(result['behavior'], 'follow')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #21

## Acceptance Criteria Checklist
- [x] Behavior interface defined
- [x] Priority order enforced
- [x] Manual control always overrides autonomy

## Summary
Implements the missing behavior framework contracts and autonomy arbitration in the control layer while preserving safety priority guarantees.

## What Changed
- Added BehaviorCommand and BehaviorProvider interface for autonomous modules
- Added autonomous command application path in ControlArbiter
- Enforced manual override window over autonomy
- Exposed active behavior in control state
- Added unit tests for autonomy application and manual override priority
- Updated control architecture docs to describe behavior contract and arbitration rules

## Required Docs Reviewed
- docs/init/CONTROL_AND_SAFETY_SPEC.md
- docs/control/ARBITECTURE.md

## Tests
- python3 -m pytest src/control/test_arbiter.py src/control/test_websocket_control.py src/api/test_control_api.py -q

## Questions/Assumptions
- Assumption: API endpoints for enabling/disabling autonomy sources are out of scope for this epic and can be introduced by downstream behavior epics.