### PR TITLE
(#23) Implement Vision Runtime (Detection + Tracking + Target Selection)

### DIFF
--- a/src/vision/detection.py
+++ b/src/vision/detection.py
@@ -9,9 +9,8 @@ any camera hardware or model binaries.
 from __future__ import annotations
 
 import logging
-import time
 from dataclasses import dataclass
-from typing import Callable, List, Optional
+from typing import Callable, List
 
 from hal.camera import CameraFrame
 
@@ -84,7 +83,6 @@ class DetectionEngine:
         # Initialise so the very first frame triggers detection.
         self._frame_count: int = interval_frames - 1
         self._last_detections: List[Detection] = []
-        self._last_detect_time: Optional[float] = None
 
     @property
     def last_detections(self) -> List[Detection]:
@@ -102,7 +100,6 @@ class DetectionEngine:
             self._last_detections = [
                 d for d in raw if d.confidence >= self._min_confidence
             ]
-            self._last_detect_time = time.monotonic()
             logger.debug(
                 "Detection ran on frame %d: %d result(s)",
                 self._frame_count,

--- a/src/vision/detection.py
+++ b/src/vision/detection.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Interval-based object detection for the TurboPi vision pipeline.
+
+Runs a detector callback every N frames against raw HAL frames.
+A mock detector is provided so the module is fully testable without
+any camera hardware or model binaries.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from hal.camera import CameraFrame
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Detection:
+    """A single detected object in a frame."""
+
+    label: str
+    confidence: float
+    # Normalised bounding box: x1, y1, x2, y2 in [0.0, 1.0]
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+    @property
+    def cx(self) -> float:
+        """Horizontal centre of bounding box (normalised)."""
+        return (self.x1 + self.x2) / 2.0
+
+    @property
+    def cy(self) -> float:
+        """Vertical centre of bounding box (normalised)."""
+        return (self.y1 + self.y2) / 2.0
+
+    @property
+    def width(self) -> float:
+        return self.x2 - self.x1
+
+    @property
+    def height(self) -> float:
+        return self.y2 - self.y1
+
+    @property
+    def area(self) -> float:
+        return self.width * self.height
+
+
+# Detector callable type: takes a CameraFrame, returns list of Detections.
+DetectorFn = Callable[[CameraFrame], List[Detection]]
+
+
+class DetectionEngine:
+    """Run object detection at a fixed frame interval.
+
+    Args:
+        detector_fn:    Callable that takes a CameraFrame and returns detections.
+        interval_frames: Run the detector once every N frames (default: 1 = every frame).
+        min_confidence:  Drop detections below this threshold.
+    """
+
+    def __init__(
+        self,
+        detector_fn: DetectorFn,
+        interval_frames: int = 1,
+        min_confidence: float = 0.3,
+    ) -> None:
+        if interval_frames < 1:
+            raise ValueError("interval_frames must be >= 1")
+        if not (0.0 <= min_confidence <= 1.0):
+            raise ValueError("min_confidence must be in [0.0, 1.0]")
+
+        self._detector_fn = detector_fn
+        self._interval = interval_frames
+        self._min_confidence = min_confidence
+
+        # Initialise so the very first frame triggers detection.
+        self._frame_count: int = interval_frames - 1
+        self._last_detections: List[Detection] = []
+        self._last_detect_time: Optional[float] = None
+
+    @property
+    def last_detections(self) -> List[Detection]:
+        """Most recent detection results (may be from a prior interval)."""
+        return list(self._last_detections)
+
+    def process_frame(self, frame: CameraFrame) -> List[Detection]:
+        """Process one frame; detector runs only on interval boundaries.
+
+        Returns the current detection list (cached between intervals).
+        """
+        self._frame_count += 1
+        if self._frame_count % self._interval == 0:
+            raw = self._detector_fn(frame)
+            self._last_detections = [
+                d for d in raw if d.confidence >= self._min_confidence
+            ]
+            self._last_detect_time = time.monotonic()
+            logger.debug(
+                "Detection ran on frame %d: %d result(s)",
+                self._frame_count,
+                len(self._last_detections),
+            )
+        return list(self._last_detections)
+
+
+# ---------------------------------------------------------------------------
+# Mock detector for testing and offline development
+# ---------------------------------------------------------------------------
+
+def mock_person_detector(frame: CameraFrame) -> List[Detection]:
+    """Deterministic detector that returns one centred 'person' detection."""
+    return [
+        Detection(
+            label="person",
+            confidence=0.85,
+            x1=0.3,
+            y1=0.1,
+            x2=0.7,
+            y2=0.9,
+        )
+    ]

--- a/src/vision/target_selector.py
+++ b/src/vision/target_selector.py
@@ -24,13 +24,18 @@ class TargetSelector:
     - **Auto**: choose the largest person in the frame when no target is held.
     - **Manual**: user has explicitly selected a track_id via the UI.
 
-    The selected target is cleared when the track is evicted (not seen for
-    ``max_missed`` frames as configured in the Tracker).
+    Temporary misses are tolerated so short occlusions do not immediately
+    clear selection. Selection is cleared only after repeated missing updates
+    or explicit clear().
     """
 
-    def __init__(self) -> None:
+    def __init__(self, max_missing_updates: int = 5) -> None:
+        if max_missing_updates < 1:
+            raise ValueError("max_missing_updates must be >= 1")
         self._selected_id: Optional[int] = None
         self._manual: bool = False
+        self._max_missing_updates = max_missing_updates
+        self._missing_updates = 0
 
     @property
     def selected_id(self) -> Optional[int]:
@@ -45,12 +50,14 @@ class TargetSelector:
         """Explicitly select a target by track ID (UI-driven)."""
         self._selected_id = track_id
         self._manual = True
+        self._missing_updates = 0
         logger.info("Target manually selected: track_id=%d", track_id)
 
     def clear(self) -> None:
         """Release the current selection and revert to auto mode."""
         self._selected_id = None
         self._manual = False
+        self._missing_updates = 0
         logger.info("Target selection cleared")
 
     def update(self, tracks: List[TrackedObject]) -> Optional[TrackedObject]:
@@ -60,18 +67,23 @@ class TargetSelector:
         - If no selection, auto-picks the largest person track.
         """
         active_ids = {t.track_id for t in tracks}
-        was_manual = self._manual
 
-        # Evict missing manual target.
+        # Missing target is tolerated for short occlusions.
         if self._selected_id is not None and self._selected_id not in active_ids:
-            logger.info(
-                "Target track %d lost; clearing selection", self._selected_id
-            )
-            self._selected_id = None
-            self._manual = False
-            if was_manual:
-                # Do not auto-select when an explicit user target is lost.
-                return None
+            self._missing_updates += 1
+            if self._missing_updates >= self._max_missing_updates:
+                logger.info(
+                    "Target track %d lost for %d update(s); clearing selection",
+                    self._selected_id,
+                    self._missing_updates,
+                )
+                self._selected_id = None
+                self._manual = False
+                self._missing_updates = 0
+            return None
+
+        # Target present; reset occlusion counter.
+        self._missing_updates = 0
 
         # Return explicit target if still present.
         if self._selected_id is not None:
@@ -87,5 +99,6 @@ class TargetSelector:
 
         target = max(persons, key=lambda t: t.detection.area)
         self._selected_id = target.track_id
+        self._manual = False
         logger.debug("Auto-selected track %d (area=%.4f)", target.track_id, target.detection.area)
         return target

--- a/src/vision/target_selector.py
+++ b/src/vision/target_selector.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Target selection for the TurboPi vision pipeline.
+
+Provides auto-selection (largest 'person' detection) and explicit
+user selection by track ID for the UI control surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from vision.tracker import TrackedObject
+
+logger = logging.getLogger(__name__)
+
+_PERSON_LABEL = "person"
+
+
+class TargetSelector:
+    """Select and hold a target track for the follow behaviour.
+
+    Selection modes:
+    - **Auto**: choose the largest person in the frame when no target is held.
+    - **Manual**: user has explicitly selected a track_id via the UI.
+
+    The selected target is cleared when the track is evicted (not seen for
+    ``max_missed`` frames as configured in the Tracker).
+    """
+
+    def __init__(self) -> None:
+        self._selected_id: Optional[int] = None
+        self._manual: bool = False
+
+    @property
+    def selected_id(self) -> Optional[int]:
+        return self._selected_id
+
+    @property
+    def is_manual(self) -> bool:
+        """True when the current selection was made explicitly by the UI."""
+        return self._manual
+
+    def select(self, track_id: int) -> None:
+        """Explicitly select a target by track ID (UI-driven)."""
+        self._selected_id = track_id
+        self._manual = True
+        logger.info("Target manually selected: track_id=%d", track_id)
+
+    def clear(self) -> None:
+        """Release the current selection and revert to auto mode."""
+        self._selected_id = None
+        self._manual = False
+        logger.info("Target selection cleared")
+
+    def update(self, tracks: List[TrackedObject]) -> Optional[TrackedObject]:
+        """Update selection against current active tracks; return target or None.
+
+        - If a manual ID is held but its track is gone, clears selection.
+        - If no selection, auto-picks the largest person track.
+        """
+        active_ids = {t.track_id for t in tracks}
+        was_manual = self._manual
+
+        # Evict missing manual target.
+        if self._selected_id is not None and self._selected_id not in active_ids:
+            logger.info(
+                "Target track %d lost; clearing selection", self._selected_id
+            )
+            self._selected_id = None
+            self._manual = False
+            if was_manual:
+                # Do not auto-select when an explicit user target is lost.
+                return None
+
+        # Return explicit target if still present.
+        if self._selected_id is not None:
+            for track in tracks:
+                if track.track_id == self._selected_id:
+                    return track
+            return None
+
+        # Auto-select: largest person by bounding-box area.
+        persons = [t for t in tracks if t.detection.label == _PERSON_LABEL]
+        if not persons:
+            return None
+
+        target = max(persons, key=lambda t: t.detection.area)
+        self._selected_id = target.track_id
+        logger.debug("Auto-selected track %d (area=%.4f)", target.track_id, target.detection.area)
+        return target

--- a/src/vision/test_detection.py
+++ b/src/vision/test_detection.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Unit tests for vision detection engine."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hal.camera import CameraCalibration, CameraFrame, FakeCameraHAL
+from vision.detection import Detection, DetectionEngine, mock_person_detector
+
+
+def _make_frame() -> CameraFrame:
+    hal = FakeCameraHAL(calibration=CameraCalibration(width=320, height=240))
+    hal.open()
+    return hal.get_frame()
+
+
+class TestDetection(unittest.TestCase):
+    def test_properties(self):
+        d = Detection(label="person", confidence=0.9, x1=0.2, y1=0.1, x2=0.8, y2=0.9)
+        self.assertAlmostEqual(d.cx, 0.5)
+        self.assertAlmostEqual(d.cy, 0.5)
+        self.assertAlmostEqual(d.width, 0.6)
+        self.assertAlmostEqual(d.height, 0.8)
+        self.assertAlmostEqual(d.area, 0.48)
+
+
+class TestDetectionEngine(unittest.TestCase):
+    def setUp(self):
+        self.frame = _make_frame()
+
+    def test_runs_detector_on_every_frame_by_default(self):
+        call_count = [0]
+
+        def counting_detector(f):
+            call_count[0] += 1
+            return mock_person_detector(f)
+
+        engine = DetectionEngine(detector_fn=counting_detector)
+        for _ in range(5):
+            engine.process_frame(self.frame)
+        self.assertEqual(call_count[0], 5)
+
+    def test_interval_frames_throttles_detection(self):
+        call_count = [0]
+
+        def counting_detector(f):
+            call_count[0] += 1
+            return mock_person_detector(f)
+
+        engine = DetectionEngine(detector_fn=counting_detector, interval_frames=3)
+        for _ in range(9):
+            engine.process_frame(self.frame)
+        self.assertEqual(call_count[0], 3)
+
+    def test_cached_results_returned_between_intervals(self):
+        engine = DetectionEngine(detector_fn=mock_person_detector, interval_frames=5)
+        results_frame1 = engine.process_frame(self.frame)
+        self.assertEqual(len(results_frame1), 1)
+        # Frame 2–4 still return the cached result.
+        for _ in range(3):
+            cached = engine.process_frame(self.frame)
+            self.assertEqual(len(cached), 1)
+
+    def test_min_confidence_filters_low_confidence(self):
+        def low_conf_detector(f):
+            return [
+                Detection(label="person", confidence=0.2, x1=0.1, y1=0.1, x2=0.5, y2=0.5)
+            ]
+
+        engine = DetectionEngine(detector_fn=low_conf_detector, min_confidence=0.5)
+        results = engine.process_frame(self.frame)
+        self.assertEqual(len(results), 0)
+
+    def test_invalid_interval_raises(self):
+        with self.assertRaises(ValueError):
+            DetectionEngine(detector_fn=mock_person_detector, interval_frames=0)
+
+    def test_invalid_confidence_raises(self):
+        with self.assertRaises(ValueError):
+            DetectionEngine(detector_fn=mock_person_detector, min_confidence=1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/vision/test_target_selector.py
+++ b/src/vision/test_target_selector.py
@@ -8,7 +8,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from vision.detection import Detection
-from vision.tracker import Tracker, TrackedObject
+from vision.tracker import TrackedObject
 from vision.target_selector import TargetSelector
 
 
@@ -42,12 +42,56 @@ class TestTargetSelector(unittest.TestCase):
         self.assertTrue(selector.is_manual)
 
     def test_manual_selection_cleared_when_track_lost(self):
-        selector = TargetSelector()
+        selector = TargetSelector(max_missing_updates=1)
         selector.select(5)
         target = selector.update([_track(1)])
         self.assertIsNone(target)
         self.assertIsNone(selector.selected_id)
         self.assertFalse(selector.is_manual)
+
+    def test_manual_selection_persists_through_temporary_miss(self):
+        selector = TargetSelector(max_missing_updates=3)
+        manual = _track(5)
+
+        selector.select(5)
+        self.assertEqual(selector.update([manual]).track_id, 5)
+
+        # Single missed update should not clear manual selection.
+        self.assertIsNone(selector.update([]))
+        self.assertEqual(selector.selected_id, 5)
+        self.assertTrue(selector.is_manual)
+
+        # Target reacquired within tolerance keeps same identity.
+        self.assertEqual(selector.update([manual]).track_id, 5)
+
+    def test_auto_selection_persists_through_temporary_miss(self):
+        selector = TargetSelector(max_missing_updates=3)
+        auto = _track(2, x1=0.1, y1=0.1, x2=0.9, y2=0.9)
+
+        first = selector.update([auto])
+        self.assertIsNotNone(first)
+        self.assertEqual(first.track_id, 2)
+        self.assertFalse(selector.is_manual)
+
+        # Single miss should not clear selected id.
+        self.assertIsNone(selector.update([]))
+        self.assertEqual(selector.selected_id, 2)
+
+        # Reappearance preserves target id.
+        second = selector.update([auto])
+        self.assertIsNotNone(second)
+        self.assertEqual(second.track_id, 2)
+
+    def test_selection_clears_after_miss_tolerance(self):
+        selector = TargetSelector(max_missing_updates=2)
+        auto = _track(2)
+
+        selector.update([auto])
+        self.assertEqual(selector.selected_id, 2)
+        selector.update([])  # first miss retained
+        self.assertEqual(selector.selected_id, 2)
+        selector.update([])  # second miss clears
+        self.assertIsNone(selector.selected_id)
 
     def test_clear_reverts_to_auto(self):
         selector = TargetSelector()

--- a/src/vision/test_target_selector.py
+++ b/src/vision/test_target_selector.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Unit tests for target selection (auto and manual modes)."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from vision.detection import Detection
+from vision.tracker import Tracker, TrackedObject
+from vision.target_selector import TargetSelector
+
+
+def _track(track_id: int, label: str = "person", x1=0.2, y1=0.1, x2=0.8, y2=0.9) -> TrackedObject:
+    det = Detection(label=label, confidence=0.85, x1=x1, y1=y1, x2=x2, y2=y2)
+    return TrackedObject(track_id=track_id, detection=det)
+
+
+class TestTargetSelector(unittest.TestCase):
+    def test_auto_selects_largest_person(self):
+        selector = TargetSelector()
+        small = _track(1, x1=0.4, y1=0.4, x2=0.6, y2=0.6)
+        large = _track(2, x1=0.1, y1=0.1, x2=0.9, y2=0.9)
+        target = selector.update([small, large])
+        self.assertIsNotNone(target)
+        self.assertEqual(target.track_id, 2)
+
+    def test_auto_ignores_non_person_labels(self):
+        selector = TargetSelector()
+        chair = _track(1, label="chair")
+        target = selector.update([chair])
+        self.assertIsNone(target)
+
+    def test_manual_select_overrides_auto(self):
+        selector = TargetSelector()
+        small = _track(1, x1=0.4, y1=0.4, x2=0.6, y2=0.6)
+        large = _track(2, x1=0.1, y1=0.1, x2=0.9, y2=0.9)
+        selector.select(1)
+        target = selector.update([small, large])
+        self.assertEqual(target.track_id, 1)
+        self.assertTrue(selector.is_manual)
+
+    def test_manual_selection_cleared_when_track_lost(self):
+        selector = TargetSelector()
+        selector.select(5)
+        target = selector.update([_track(1)])
+        self.assertIsNone(target)
+        self.assertIsNone(selector.selected_id)
+        self.assertFalse(selector.is_manual)
+
+    def test_clear_reverts_to_auto(self):
+        selector = TargetSelector()
+        large = _track(2, x1=0.1, y1=0.1, x2=0.9, y2=0.9)
+        selector.select(99)
+        selector.clear()
+        self.assertFalse(selector.is_manual)
+        target = selector.update([large])
+        self.assertEqual(target.track_id, 2)
+
+    def test_no_tracks_returns_none(self):
+        selector = TargetSelector()
+        self.assertIsNone(selector.update([]))
+
+    def test_identity_persists_across_frames(self):
+        selector = TargetSelector()
+        track = _track(3)
+        selector.update([track])
+        first_id = selector.selected_id
+        selector.update([track])
+        self.assertEqual(selector.selected_id, first_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/vision/test_tracker.py
+++ b/src/vision/test_tracker.py
@@ -74,6 +74,14 @@ class TestTracker(unittest.TestCase):
         tracker.update([])
         self.assertEqual(len(tracker.all_tracks), 1)
 
+    def test_track_evicted_at_max_missed_boundary(self):
+        tracker = Tracker(max_missed=2)
+        tracker.update([_det()])
+        tracker.update([])  # missed=1
+        self.assertEqual(len(tracker.all_tracks), 1)
+        tracker.update([])  # missed=2 => evicted
+        self.assertEqual(len(tracker.all_tracks), 0)
+
     def test_identity_persists_through_miss_and_recovery(self):
         tracker = Tracker(max_missed=3)
         tracker.update([_det()])

--- a/src/vision/test_tracker.py
+++ b/src/vision/test_tracker.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Unit tests for the IoU-based vision tracker."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from vision.detection import Detection
+from vision.tracker import Tracker, _iou
+
+
+def _det(x1=0.1, y1=0.1, x2=0.5, y2=0.5, label="person", confidence=0.9) -> Detection:
+    return Detection(label=label, confidence=confidence, x1=x1, y1=y1, x2=x2, y2=y2)
+
+
+class TestIou(unittest.TestCase):
+    def test_perfect_overlap(self):
+        d = _det()
+        self.assertAlmostEqual(_iou(d, d), 1.0)
+
+    def test_no_overlap(self):
+        a = _det(x1=0.0, y1=0.0, x2=0.2, y2=0.2)
+        b = _det(x1=0.5, y1=0.5, x2=0.9, y2=0.9)
+        self.assertAlmostEqual(_iou(a, b), 0.0)
+
+    def test_partial_overlap(self):
+        a = _det(x1=0.0, y1=0.0, x2=0.5, y2=0.5)
+        b = _det(x1=0.25, y1=0.25, x2=0.75, y2=0.75)
+        iou = _iou(a, b)
+        self.assertGreater(iou, 0.0)
+        self.assertLess(iou, 1.0)
+
+
+class TestTracker(unittest.TestCase):
+    def test_new_detection_creates_track(self):
+        tracker = Tracker()
+        tracks = tracker.update([_det()])
+        self.assertEqual(len(tracks), 1)
+        self.assertEqual(tracks[0].track_id, 1)
+        self.assertEqual(tracks[0].age, 1)
+
+    def test_same_detection_increments_age(self):
+        tracker = Tracker()
+        tracker.update([_det()])
+        tracks = tracker.update([_det()])
+        self.assertEqual(len(tracks), 1)
+        self.assertEqual(tracks[0].age, 2)
+        self.assertEqual(tracks[0].track_id, 1)
+
+    def test_separate_detections_get_separate_ids(self):
+        tracker = Tracker()
+        a = _det(x1=0.0, y1=0.0, x2=0.2, y2=0.2)
+        b = _det(x1=0.6, y1=0.6, x2=0.9, y2=0.9)
+        tracks = tracker.update([a, b])
+        ids = {t.track_id for t in tracks}
+        self.assertEqual(len(ids), 2)
+
+    def test_missing_track_evicted_after_max_missed(self):
+        tracker = Tracker(max_missed=2)
+        tracker.update([_det()])
+        # Stop providing this detection — track should be evicted after 2 missed.
+        tracker.update([])
+        tracker.update([])
+        tracker.update([])
+        self.assertEqual(len(tracker.all_tracks), 0)
+
+    def test_track_not_evicted_before_max_missed(self):
+        tracker = Tracker(max_missed=3)
+        tracker.update([_det()])
+        # Miss 2 frames (below threshold of 3).
+        tracker.update([])
+        tracker.update([])
+        self.assertEqual(len(tracker.all_tracks), 1)
+
+    def test_identity_persists_through_miss_and_recovery(self):
+        tracker = Tracker(max_missed=3)
+        tracker.update([_det()])
+        original_id = tracker.all_tracks[0].track_id
+        tracker.update([])  # 1 miss
+        tracker.update([_det()])  # re-matched
+        self.assertEqual(tracker.active_tracks[0].track_id, original_id)
+
+    def test_invalid_iou_threshold_raises(self):
+        with self.assertRaises(ValueError):
+            Tracker(iou_threshold=0.0)
+
+    def test_invalid_max_missed_raises(self):
+        with self.assertRaises(ValueError):
+            Tracker(max_missed=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/vision/tracker.py
+++ b/src/vision/tracker.py
@@ -8,7 +8,7 @@ across frames, with configurable lost-target eviction.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from vision.detection import Detection
@@ -50,7 +50,8 @@ class Tracker:
 
     Args:
         iou_threshold:   Minimum IoU to match a detection to an existing track.
-        max_missed:      Evict a track after it has been absent this many frames.
+        max_missed:      Maximum consecutive misses to retain a track.
+                         The track is evicted when missed_frames >= max_missed.
     """
 
     def __init__(self, iou_threshold: float = 0.3, max_missed: int = 5) -> None:
@@ -110,7 +111,7 @@ class Tracker:
             self._next_id += 1
 
         # Evict stale tracks.
-        stale = [tid for tid, t in self._tracks.items() if t.missed_frames > self._max_missed]
+        stale = [tid for tid, t in self._tracks.items() if t.missed_frames >= self._max_missed]
         for tid in stale:
             logger.debug("Track %d evicted (missed %d frames)", tid, self._tracks[tid].missed_frames)
             del self._tracks[tid]

--- a/src/vision/tracker.py
+++ b/src/vision/tracker.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Per-frame object tracker with persistent identity assignment.
+
+Uses IoU-based greedy matching to assign stable integer IDs to detections
+across frames, with configurable lost-target eviction.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from vision.detection import Detection
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TrackedObject:
+    """A detection annotated with a persistent track ID."""
+
+    track_id: int
+    detection: Detection
+    # Number of consecutive frames this object has been seen.
+    age: int = 1
+    # Number of consecutive frames this object has been missing.
+    missed_frames: int = 0
+
+
+def _iou(a: Detection, b: Detection) -> float:
+    """Compute Intersection-over-Union of two bounding boxes."""
+    ix1 = max(a.x1, b.x1)
+    iy1 = max(a.y1, b.y1)
+    ix2 = min(a.x2, b.x2)
+    iy2 = min(a.y2, b.y2)
+
+    inter_w = max(0.0, ix2 - ix1)
+    inter_h = max(0.0, iy2 - iy1)
+    inter_area = inter_w * inter_h
+
+    union_area = a.area + b.area - inter_area
+    if union_area <= 0.0:
+        return 0.0
+    return inter_area / union_area
+
+
+class Tracker:
+    """Greedy IoU tracker assigning persistent IDs to detected objects.
+
+    Args:
+        iou_threshold:   Minimum IoU to match a detection to an existing track.
+        max_missed:      Evict a track after it has been absent this many frames.
+    """
+
+    def __init__(self, iou_threshold: float = 0.3, max_missed: int = 5) -> None:
+        if not (0.0 < iou_threshold <= 1.0):
+            raise ValueError("iou_threshold must be in (0.0, 1.0]")
+        if max_missed < 1:
+            raise ValueError("max_missed must be >= 1")
+
+        self._iou_threshold = iou_threshold
+        self._max_missed = max_missed
+        self._tracks: Dict[int, TrackedObject] = {}
+        self._next_id: int = 1
+
+    @property
+    def active_tracks(self) -> List[TrackedObject]:
+        """Currently tracked objects (missed_frames == 0)."""
+        return [t for t in self._tracks.values() if t.missed_frames == 0]
+
+    @property
+    def all_tracks(self) -> List[TrackedObject]:
+        return list(self._tracks.values())
+
+    def update(self, detections: List[Detection]) -> List[TrackedObject]:
+        """Match detections to existing tracks; create new tracks for unmatched.
+
+        Returns the list of tracks that have an active detection this frame.
+        """
+        # Mark all tracks as missed initially.
+        for track in self._tracks.values():
+            track.missed_frames += 1
+
+        unmatched_detections = list(detections)
+
+        for track in self._tracks.values():
+            if not unmatched_detections:
+                break
+            best_iou = 0.0
+            best_det: Optional[Detection] = None
+            for det in unmatched_detections:
+                score = _iou(track.detection, det)
+                if score > best_iou:
+                    best_iou = score
+                    best_det = det
+
+            if best_det is not None and best_iou >= self._iou_threshold:
+                track.detection = best_det
+                track.missed_frames = 0
+                track.age += 1
+                unmatched_detections.remove(best_det)
+                logger.debug("Track %d matched (IoU=%.2f)", track.track_id, best_iou)
+
+        # New tracks for unmatched detections.
+        for det in unmatched_detections:
+            new_track = TrackedObject(track_id=self._next_id, detection=det)
+            self._tracks[self._next_id] = new_track
+            logger.debug("New track %d created", self._next_id)
+            self._next_id += 1
+
+        # Evict stale tracks.
+        stale = [tid for tid, t in self._tracks.items() if t.missed_frames > self._max_missed]
+        for tid in stale:
+            logger.debug("Track %d evicted (missed %d frames)", tid, self._tracks[tid].missed_frames)
+            del self._tracks[tid]
+
+        return self.active_tracks


### PR DESCRIPTION
Closes #23

## Acceptance Criteria Checklist
- [x] Detection at fixed interval
- [x] Tracking per frame with persistent IDs
- [x] Target identity persists across frames
- [x] Manual target selection (UI-driven) with auto-fallback

## Summary
Implements the full vision runtime pipeline: interval-based detection, IoU-based per-frame tracking with persistent IDs, and target selection supporting both automatic (largest person) and explicit UI-driven selection.

## What Changed
- `src/vision/detection.py` — `DetectionEngine`: runs detector every N frames, caches results, enforces min confidence; includes `mock_person_detector` for testing
- `src/vision/tracker.py` — `Tracker`: greedy IoU matching assigning stable integer IDs, configurable eviction on missed frames
- `src/vision/target_selector.py` — `TargetSelector`: auto-selects largest person; UI can override with `select(track_id)`; clears on lost-track
- `src/vision/test_detection.py` — 6 tests
- `src/vision/test_tracker.py` — 8 tests
- `src/vision/test_target_selector.py` — 7 tests

## Required Docs Reviewed
- docs/init/VISION_AND_FOLLOW_SPEC.md
- docs/vision/MODEL_DISCOVERY.md

## Tests
```
python3 -m pytest src/vision/ -q
```

## Questions/Assumptions
- Assumption: UI target-selection API endpoint (exposing `TargetSelector.select()` over HTTP) is scoped to a downstream epic when the full UI/WS control surface is implemented.