### PR TITLE
(#24) Implement Follow Behavior v1

### DIFF
--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -437,6 +437,144 @@ paths:
                   max_linear_speed: { type: number }
                   max_angular_speed: { type: number }
 
+  /control/follow/start:
+    post:
+      summary: Start follow behavior
+      description: Enables autonomous follow behavior for an optional target id selected by UI.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                target_id:
+                  type: integer
+                  minimum: 1
+      responses:
+        '200':
+          description: Follow behavior started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: "started" }
+                  target_id:
+                    type: integer
+                    nullable: true
+        '400':
+          description: Invalid request payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "bad_request" }
+                  message: { type: string }
+        '403':
+          description: Request origin is not allowed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "forbidden" }
+                  message: { type: string }
+
+  /control/follow/stop:
+    post:
+      summary: Stop follow behavior
+      description: Disables follow behavior and forces zero motion output.
+      responses:
+        '200':
+          description: Follow behavior stopped
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: "stopped" }
+        '403':
+          description: Request origin is not allowed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "forbidden" }
+                  message: { type: string }
+
+  /control/follow/state:
+    get:
+      summary: Get follow behavior state
+      responses:
+        '200':
+          description: Current follow behavior state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled: { type: boolean }
+                  target_id:
+                    type: integer
+                    nullable: true
+                  lost_target: { type: boolean }
+                  linear_mps: { type: number }
+                  angular_rps: { type: number }
+
+  /control/follow/observation:
+    post:
+      summary: Submit target observation for follow control
+      description: Supplies latest selected-target observation from vision runtime/UI selection layer.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [target_id, center_x, area]
+              properties:
+                target_id:
+                  type: integer
+                  minimum: 1
+                center_x:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+                area:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+      responses:
+        '200':
+          description: Observation accepted or ignored (target mismatch)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, enum: [accepted, ignored] }
+        '400':
+          description: Invalid request payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "bad_request" }
+                  message: { type: string }
+        '403':
+          description: Request origin is not allowed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string, example: "forbidden" }
+                  message: { type: string }
+
   /video/stream:
     get:
       summary: MJPEG live camera stream

--- a/docs/control/ARBITECTURE.md
+++ b/docs/control/ARBITECTURE.md
@@ -11,6 +11,7 @@
 - WebSocket manual commands
 - Voice command intents
 - Autonomy outputs
+- Follow behavior target observations (`target_id`, `center_x`, `area`)
 
 ## Behavior Interface
 - Autonomous behaviors emit `BehaviorCommand` envelopes with `behavior`, `linear_mps`, and `angular_rps`
@@ -26,3 +27,5 @@
 - Safety overrides never bypassed
 - Manual commands override autonomy for the configured manual override window
 - Autonomous commands are accepted only when the robot is armed and manual override is inactive
+- Follow behavior outputs are smoothed and routed through `ControlArbiter.apply_autonomy()`
+- Lost target handling must force zero motion until a fresh observation is available

--- a/docs/ui/UI_BEHAVIOR.md
+++ b/docs/ui/UI_BEHAVIOR.md
@@ -25,6 +25,9 @@
 - Disarm button calls POST /control/disarm
 - E-Stop button calls POST /control/estop
 - Reset E-Stop button calls POST /control/estop/reset
+- Start Follow button calls POST /control/follow/start with optional target_id
+- Stop Follow button calls POST /control/follow/stop
+- UI polls GET /control/follow/state to display follow enabled/lost-target state
 - Joystick uses WebSocket control channel (/ws/control)
 - Joystick release sends stop command
 - WebSocket disconnect or heartbeat timeout must stop motion immediately

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -37,7 +37,7 @@ except Exception as exc:
 
 # Add control/HAL imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-from control import ControlArbiter, ControlWebSocketBridge
+from control import ControlArbiter, ControlWebSocketBridge, FollowBehavior, TargetObservation
 from hal import CameraError, FakeCameraHAL
 
 # Import wake word engine and command parser (add path for imports)
@@ -519,6 +519,11 @@ class APIHandler(BaseHTTPRequestHandler):
     _video_frames_total = 0
     _video_last_frame_ts = 0.0
     _video_fps = 0.0
+
+    # Global follow behavior runtime
+    _follow_behavior: Optional[FollowBehavior] = None
+    _follow_lock = threading.Lock()
+    _follow_thread_started = False
     
     @classmethod
     def get_wake_word_engine(cls):
@@ -564,6 +569,35 @@ class APIHandler(BaseHTTPRequestHandler):
             elif not cls._camera_hal.is_open():
                 cls._camera_hal.open()
             return cls._camera_hal
+
+    @classmethod
+    def get_follow_behavior(cls):
+        """Get or create follow behavior singleton and runtime loop."""
+        with cls._follow_lock:
+            if cls._follow_behavior is None:
+                cls._follow_behavior = FollowBehavior()
+                logging.info("Follow behavior initialized")
+
+            if not cls._follow_thread_started:
+                thread = threading.Thread(target=cls._run_follow_loop, daemon=True)
+                thread.start()
+                cls._follow_thread_started = True
+                logging.info("Follow behavior runtime loop started")
+
+            return cls._follow_behavior
+
+    @classmethod
+    def _run_follow_loop(cls) -> None:
+        """Apply follow behavior autonomy commands on a fixed cadence."""
+        while True:
+            behavior = cls.get_follow_behavior()
+            command = behavior.next_command()
+            if command is not None:
+                result = cls.get_control_arbiter().apply_autonomy(command)
+                if result.get('status') == 'blocked':
+                    # Safety states (for example E-Stop) disable follow immediately.
+                    behavior.stop()
+            time.sleep(0.1)
 
     @classmethod
     def record_video_frame(cls) -> None:
@@ -687,6 +721,8 @@ class APIHandler(BaseHTTPRequestHandler):
             self.handle_health()
         elif path == '/control/state':
             self.handle_control_state()
+        elif path == '/control/follow/state':
+            self.handle_control_follow_state()
         elif path == '/system/version':
             self.handle_system_version()
         elif path == '/updates/check':
@@ -716,6 +752,12 @@ class APIHandler(BaseHTTPRequestHandler):
             self.handle_control_estop()
         elif self.path == '/control/estop/reset':
             self.handle_control_estop_reset()
+        elif self.path == '/control/follow/start':
+            self.handle_control_follow_start()
+        elif self.path == '/control/follow/stop':
+            self.handle_control_follow_stop()
+        elif self.path == '/control/follow/observation':
+            self.handle_control_follow_observation()
         elif self.path == '/system/restart':
             self.handle_system_restart()
         elif self.path == '/system/reboot':
@@ -868,6 +910,7 @@ class APIHandler(BaseHTTPRequestHandler):
         """Handle POST /control/disarm endpoint."""
         if not self._require_ui_origin():
             return
+        self.get_follow_behavior().stop()
         arbiter = self.get_control_arbiter()
         self._send_json_response(200, arbiter.disarm())
 
@@ -875,6 +918,7 @@ class APIHandler(BaseHTTPRequestHandler):
         """Handle POST /control/estop endpoint."""
         if not self._require_ui_origin():
             return
+        self.get_follow_behavior().stop()
         arbiter = self.get_control_arbiter()
         self._send_json_response(200, arbiter.engage_estop())
 
@@ -889,6 +933,88 @@ class APIHandler(BaseHTTPRequestHandler):
         """Handle GET /control/state endpoint."""
         arbiter = self.get_control_arbiter()
         self._send_json_response(200, arbiter.get_state().to_dict())
+
+    def handle_control_follow_state(self):
+        """Handle GET /control/follow/state endpoint."""
+        follow = self.get_follow_behavior()
+        self._send_json_response(200, follow.state())
+
+    def handle_control_follow_start(self):
+        """Handle POST /control/follow/start endpoint."""
+        if not self._require_ui_origin():
+            return
+
+        target_id = None
+        content_length = int(self.headers.get('Content-Length', 0))
+        if content_length > 0:
+            try:
+                body = self.rfile.read(content_length).decode('utf-8')
+                payload = json.loads(body)
+                if 'target_id' in payload and payload['target_id'] is not None:
+                    target_id = int(payload['target_id'])
+                    if target_id < 1:
+                        raise ValueError('target_id must be >= 1')
+            except (json.JSONDecodeError, ValueError, TypeError):
+                self._send_json_response(400, {
+                    'error': 'bad_request',
+                    'message': 'Invalid follow start payload. Optional target_id must be a positive integer.',
+                })
+                return
+
+        follow = self.get_follow_behavior()
+        self._send_json_response(200, follow.start(target_id=target_id))
+
+    def handle_control_follow_stop(self):
+        """Handle POST /control/follow/stop endpoint."""
+        if not self._require_ui_origin():
+            return
+
+        follow = self.get_follow_behavior()
+        follow.stop()
+        self.get_control_arbiter().stop()
+        self._send_json_response(200, {'status': 'stopped'})
+
+    def handle_control_follow_observation(self):
+        """Handle POST /control/follow/observation endpoint."""
+        if not self._require_ui_origin():
+            return
+
+        content_length = int(self.headers.get('Content-Length', 0))
+        if content_length <= 0:
+            self._send_json_response(400, {
+                'error': 'bad_request',
+                'message': 'Request body is required.',
+            })
+            return
+
+        try:
+            payload = json.loads(self.rfile.read(content_length).decode('utf-8'))
+            target_id = int(payload['target_id'])
+            center_x = float(payload['center_x'])
+            area = float(payload['area'])
+            if target_id < 1:
+                raise ValueError('target_id must be >= 1')
+            if not (0.0 <= center_x <= 1.0):
+                raise ValueError('center_x must be in [0.0, 1.0]')
+            if not (0.0 <= area <= 1.0):
+                raise ValueError('area must be in [0.0, 1.0]')
+        except (KeyError, ValueError, TypeError, json.JSONDecodeError):
+            self._send_json_response(400, {
+                'error': 'bad_request',
+                'message': 'Payload must include target_id (int), center_x [0..1], area [0..1].',
+            })
+            return
+
+        follow = self.get_follow_behavior()
+        accepted = follow.update_observation(
+            TargetObservation(
+                target_id=target_id,
+                center_x=center_x,
+                area=area,
+                timestamp=time.monotonic(),
+            )
+        )
+        self._send_json_response(200, {'status': 'accepted' if accepted else 'ignored'})
 
     def handle_video_stream(self, query: str):
         """Handle GET /video/stream endpoint with multipart MJPEG output."""

--- a/src/api/test_follow_api.py
+++ b/src/api/test_follow_api.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Integration tests for follow behavior API endpoints."""
+
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from http.server import HTTPServer
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from main import APIHandler
+
+
+class TestFollowAPI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['API_HOST'] = 'localhost'
+        os.environ['API_PORT'] = '18085'
+        os.environ['UI_PORT'] = '8081'
+
+        # Reset singletons to isolate behavior from other test modules.
+        APIHandler._control_arbiter = None
+        APIHandler._camera_hal = None
+        APIHandler._follow_behavior = None
+        APIHandler._follow_thread_started = False
+
+        cls.server = HTTPServer(('localhost', 18085), APIHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        time.sleep(0.5)
+        cls.base = 'http://localhost:18085'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join(timeout=5)
+
+    def _post_json(self, path, payload=None, with_origin=True):
+        body = b'' if payload is None else json.dumps(payload).encode('utf-8')
+
+        def _send_once():
+            req = urllib.request.Request(f'{self.base}{path}', data=body, method='POST')
+            if payload is not None:
+                req.add_header('Content-Type', 'application/json')
+            if with_origin:
+                req.add_header('Origin', 'http://localhost:8081')
+            with urllib.request.urlopen(req, timeout=5) as response:
+                raw = response.read().decode()
+                return response.status, json.loads(raw) if raw else {}
+
+        try:
+            return _send_once()
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode()
+            return exc.code, json.loads(raw) if raw else {}
+        except urllib.error.URLError:
+            # Local ephemeral CI/network race; retry once for deterministic tests.
+            return _send_once()
+
+    def _get_json(self, path):
+        req = urllib.request.Request(f'{self.base}{path}', method='GET')
+        with urllib.request.urlopen(req, timeout=5) as response:
+            raw = response.read().decode()
+            return response.status, json.loads(raw) if raw else {}
+
+    def test_follow_start_requires_ui_origin(self):
+        status, payload = self._post_json('/control/follow/start', {'target_id': 1}, with_origin=False)
+        self.assertEqual(status, 403)
+        self.assertEqual(payload.get('error'), 'forbidden')
+
+    def test_follow_start_and_state(self):
+        status, payload = self._post_json('/control/follow/start', {'target_id': 1})
+        self.assertEqual(status, 200)
+        self.assertEqual(payload.get('status'), 'started')
+
+        status, state = self._get_json('/control/follow/state')
+        self.assertEqual(status, 200)
+        self.assertTrue(state.get('enabled'))
+        self.assertEqual(state.get('target_id'), 1)
+
+    def test_follow_observation_drives_autonomous_mode(self):
+        self._post_json('/control/disarm')
+        self._post_json('/control/estop/reset')
+        self._post_json('/control/arm')
+        self._post_json('/control/follow/start', {'target_id': 1})
+
+        status, payload = self._post_json(
+            '/control/follow/observation',
+            {'target_id': 1, 'center_x': 0.75, 'area': 0.08},
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(payload.get('status'), 'accepted')
+
+        time.sleep(0.25)
+        status, control = self._get_json('/control/state')
+        self.assertEqual(status, 200)
+        self.assertEqual(control.get('mode'), 'autonomous')
+        self.assertEqual(control.get('active_behavior'), 'follow')
+
+    def test_lost_target_handling_stops_motion(self):
+        self._post_json('/control/disarm')
+        self._post_json('/control/estop/reset')
+        self._post_json('/control/arm')
+        self._post_json('/control/follow/start', {'target_id': 1})
+        self._post_json('/control/follow/observation', {'target_id': 1, 'center_x': 0.8, 'area': 0.05})
+
+        time.sleep(0.25)
+        status, active_state = self._get_json('/control/state')
+        self.assertEqual(status, 200)
+        self.assertGreater(abs(active_state.get('linear_mps', 0.0)), 0.0)
+
+        # Wait longer than follow target timeout to trigger lost-target decay.
+        time.sleep(1.1)
+        status, follow_state = self._get_json('/control/follow/state')
+        self.assertEqual(status, 200)
+        self.assertTrue(follow_state.get('lost_target'))
+
+        status, control_state = self._get_json('/control/state')
+        self.assertEqual(status, 200)
+        self.assertAlmostEqual(control_state.get('linear_mps', 0.0), 0.0, places=2)
+
+    def test_estop_overrides_follow_and_disables_it(self):
+        self._post_json('/control/disarm')
+        self._post_json('/control/estop/reset')
+        self._post_json('/control/arm')
+        self._post_json('/control/follow/start', {'target_id': 1})
+        self._post_json('/control/follow/observation', {'target_id': 1, 'center_x': 0.2, 'area': 0.06})
+        time.sleep(0.2)
+
+        status, _payload = self._post_json('/control/estop')
+        self.assertEqual(status, 200)
+
+        status, control = self._get_json('/control/state')
+        self.assertEqual(status, 200)
+        self.assertTrue(control.get('estop_latched'))
+        self.assertAlmostEqual(control.get('linear_mps', 0.0), 0.0, places=3)
+        self.assertAlmostEqual(control.get('angular_rps', 0.0), 0.0, places=3)
+
+        status, follow = self._get_json('/control/follow/state')
+        self.assertEqual(status, 200)
+        self.assertFalse(follow.get('enabled'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/control/__init__.py
+++ b/src/control/__init__.py
@@ -2,10 +2,13 @@
 """Control layer exports for teleoperation and safety-aware motion routing."""
 
 from .arbiter import ControlArbiter, ControlState
+from .follow_behavior import FollowBehavior, TargetObservation
 from .websocket_control import ControlWebSocketBridge
 
 __all__ = [
     'ControlArbiter',
     'ControlState',
+    'FollowBehavior',
+    'TargetObservation',
     'ControlWebSocketBridge',
 ]

--- a/src/control/follow_behavior.py
+++ b/src/control/follow_behavior.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Follow behavior controller for autonomous target following.
+
+This module converts target observations into smooth velocity commands and
+never bypasses the control arbiter.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from control.behavior import BehaviorCommand
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(value, maximum))
+
+
+@dataclass(frozen=True)
+class TargetObservation:
+    """Normalized target observation from vision runtime.
+
+    Attributes:
+        target_id: Track id of observed target.
+        center_x: Horizontal center in [0.0, 1.0]. 0.5 is image center.
+        area: Normalized bounding-box area in [0.0, 1.0].
+        timestamp: Monotonic timestamp when observed.
+    """
+
+    target_id: int
+    center_x: float
+    area: float
+    timestamp: float
+
+
+class FollowBehavior:
+    """Stateful follow controller with smoothing and lost-target handling."""
+
+    def __init__(
+        self,
+        *,
+        desired_area: float = 0.16,
+        linear_kp: float = 1.1,
+        angular_kp: float = 2.0,
+        dead_zone_x: float = 0.04,
+        dead_zone_area: float = 0.015,
+        smooth_alpha: float = 0.35,
+        max_linear_mps: float = 0.30,
+        max_angular_rps: float = 1.0,
+        target_timeout_s: float = 0.8,
+    ) -> None:
+        self._desired_area = desired_area
+        self._linear_kp = linear_kp
+        self._angular_kp = angular_kp
+        self._dead_zone_x = dead_zone_x
+        self._dead_zone_area = dead_zone_area
+        self._smooth_alpha = smooth_alpha
+        self._max_linear_mps = max_linear_mps
+        self._max_angular_rps = max_angular_rps
+        self._target_timeout_s = target_timeout_s
+
+        self._lock = threading.Lock()
+        self._enabled = False
+        self._target_id: Optional[int] = None
+        self._observation: Optional[TargetObservation] = None
+        self._lost_target = False
+        self._linear = 0.0
+        self._angular = 0.0
+
+    def start(self, target_id: Optional[int]) -> dict:
+        """Enable follow behavior for an optional target id."""
+        with self._lock:
+            self._enabled = True
+            self._target_id = target_id
+            self._lost_target = False
+        return {'status': 'started', 'target_id': target_id}
+
+    def stop(self) -> dict:
+        """Disable follow behavior and clear output state."""
+        with self._lock:
+            self._enabled = False
+            self._lost_target = False
+            self._linear = 0.0
+            self._angular = 0.0
+        return {'status': 'stopped'}
+
+    def update_observation(self, observation: TargetObservation) -> bool:
+        """Record the latest target observation.
+
+        Returns True if the observation was accepted for control, False when
+        ignored (for example mismatched target id while a specific target is set).
+        """
+        with self._lock:
+            if self._target_id is not None and observation.target_id != self._target_id:
+                return False
+            self._observation = observation
+            self._lost_target = False
+            return True
+
+    def state(self) -> dict:
+        with self._lock:
+            return {
+                'enabled': self._enabled,
+                'target_id': self._target_id,
+                'lost_target': self._lost_target,
+                'linear_mps': self._linear,
+                'angular_rps': self._angular,
+            }
+
+    def next_command(self, now: Optional[float] = None) -> Optional[BehaviorCommand]:
+        """Compute the next smoothed follow command."""
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            if not self._enabled:
+                return None
+
+            raw_linear = 0.0
+            raw_angular = 0.0
+
+            if self._observation is None or (now - self._observation.timestamp) > self._target_timeout_s:
+                self._lost_target = True
+                self._linear = 0.0
+                self._angular = 0.0
+                return BehaviorCommand(
+                    behavior='follow',
+                    linear_mps=0.0,
+                    angular_rps=0.0,
+                )
+            else:
+                self._lost_target = False
+                x_error = self._observation.center_x - 0.5
+                if abs(x_error) < self._dead_zone_x:
+                    x_error = 0.0
+
+                area_error = self._desired_area - self._observation.area
+                if abs(area_error) < self._dead_zone_area:
+                    area_error = 0.0
+
+                raw_linear = _clamp(
+                    self._linear_kp * area_error,
+                    -self._max_linear_mps,
+                    self._max_linear_mps,
+                )
+                raw_angular = _clamp(
+                    self._angular_kp * x_error,
+                    -self._max_angular_rps,
+                    self._max_angular_rps,
+                )
+
+            # Exponential smoothing to reduce abrupt velocity changes.
+            self._linear = (self._smooth_alpha * raw_linear) + ((1.0 - self._smooth_alpha) * self._linear)
+            self._angular = (self._smooth_alpha * raw_angular) + ((1.0 - self._smooth_alpha) * self._angular)
+
+            if abs(self._linear) < 1e-3:
+                self._linear = 0.0
+            if abs(self._angular) < 1e-3:
+                self._angular = 0.0
+
+            return BehaviorCommand(
+                behavior='follow',
+                linear_mps=self._linear,
+                angular_rps=self._angular,
+            )

--- a/src/control/test_follow_behavior.py
+++ b/src/control/test_follow_behavior.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Unit tests for follow behavior control logic."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from control.follow_behavior import FollowBehavior, TargetObservation
+
+
+class TestFollowBehavior(unittest.TestCase):
+    def test_no_command_when_disabled(self):
+        behavior = FollowBehavior()
+        self.assertIsNone(behavior.next_command(now=10.0))
+
+    def test_start_and_stop(self):
+        behavior = FollowBehavior()
+        self.assertEqual(behavior.start(target_id=3)['status'], 'started')
+        self.assertTrue(behavior.state()['enabled'])
+        self.assertEqual(behavior.stop()['status'], 'stopped')
+        self.assertFalse(behavior.state()['enabled'])
+
+    def test_generates_forward_and_turn_command(self):
+        behavior = FollowBehavior(smooth_alpha=1.0)
+        behavior.start(target_id=7)
+        accepted = behavior.update_observation(
+            TargetObservation(target_id=7, center_x=0.75, area=0.08, timestamp=20.0)
+        )
+        self.assertTrue(accepted)
+        cmd = behavior.next_command(now=20.1)
+        self.assertIsNotNone(cmd)
+        self.assertGreater(cmd.linear_mps, 0.0)
+        self.assertGreater(cmd.angular_rps, 0.0)
+
+    def test_target_mismatch_is_ignored(self):
+        behavior = FollowBehavior(smooth_alpha=1.0)
+        behavior.start(target_id=2)
+        accepted = behavior.update_observation(
+            TargetObservation(target_id=9, center_x=0.5, area=0.15, timestamp=1.0)
+        )
+        self.assertFalse(accepted)
+        cmd = behavior.next_command(now=2.0)
+        self.assertEqual(cmd.linear_mps, 0.0)
+        self.assertEqual(cmd.angular_rps, 0.0)
+
+    def test_lost_target_decays_to_stop(self):
+        behavior = FollowBehavior(smooth_alpha=0.5, target_timeout_s=0.5)
+        behavior.start(target_id=1)
+        behavior.update_observation(
+            TargetObservation(target_id=1, center_x=0.9, area=0.05, timestamp=5.0)
+        )
+        cmd1 = behavior.next_command(now=5.1)
+        self.assertGreater(abs(cmd1.linear_mps) + abs(cmd1.angular_rps), 0.0)
+
+        cmd2 = behavior.next_command(now=6.0)
+        self.assertLess(abs(cmd2.linear_mps), abs(cmd1.linear_mps))
+        self.assertLess(abs(cmd2.angular_rps), abs(cmd1.angular_rps))
+        self.assertTrue(behavior.state()['lost_target'])
+
+    def test_smoothing_reduces_jump(self):
+        behavior = FollowBehavior(smooth_alpha=0.2)
+        behavior.start(target_id=1)
+        behavior.update_observation(
+            TargetObservation(target_id=1, center_x=1.0, area=0.01, timestamp=1.0)
+        )
+        cmd = behavior.next_command(now=1.01)
+        # With smoothing alpha=0.2, command should not jump to max instantly.
+        self.assertLess(abs(cmd.angular_rps), 1.0)
+        self.assertLess(abs(cmd.linear_mps), 0.30)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -280,6 +280,12 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 <button class="button button-danger" onclick="engageEstop()">E-Stop</button>
                 <button class="button button-secondary" onclick="resetEstop()">Reset E-Stop</button>
             </div>
+            <div style="display:flex; gap:10px; flex-wrap:wrap; margin-bottom:15px; align-items:center;">
+                <label for="followTargetId" style="font-weight:600;">Follow Target ID</label>
+                <input id="followTargetId" type="number" min="1" value="1" style="width:90px; padding:8px; border:1px solid #d0d7de; border-radius:6px;" />
+                <button class="button" onclick="startFollow()">Start Follow</button>
+                <button class="button button-secondary" onclick="stopFollow()">Stop Follow</button>
+            </div>
             <div class="joystick-wrap">
                 <div id="joystickPad" class="joystick-pad">
                     <div id="joystickKnob" class="joystick-knob"></div>
@@ -289,6 +295,8 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                     <p>Armed: <span id="armedValue" class="current-value">no</span></p>
                     <p>E-Stop Latched: <span id="estopValue" class="current-value">no</span></p>
                     <p>Deadman Triggered: <span id="deadmanValue" class="current-value">no</span></p>
+                    <p>Follow Enabled: <span id="followEnabledValue" class="current-value">no</span></p>
+                    <p>Follow Lost Target: <span id="followLostValue" class="current-value">no</span></p>
                     <p>Drive Linear: <span id="linearValue" class="current-value">0.00</span> m/s</p>
                     <p>Drive Angular: <span id="angularValue" class="current-value">0.00</span> rad/s</p>
                     <p class="info">Disconnect or missing heartbeat triggers immediate STOP.</p>
@@ -533,6 +541,38 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             await refreshControlState();
         }}
 
+        async function startFollow() {{
+            const targetInput = document.getElementById('followTargetId');
+            const rawTarget = parseInt(targetInput.value, 10);
+            const payload = Number.isFinite(rawTarget) && rawTarget > 0
+                ? {{ target_id: rawTarget }}
+                : {{}};
+
+            const response = await fetch(API_BASE + '/control/follow/start', {{
+                method: 'POST',
+                headers: {{ 'Content-Type': 'application/json' }},
+                body: JSON.stringify(payload),
+            }});
+            const data = await parseApiPayload(response);
+            if (!response.ok) {{
+                showControlAlert(data.message || 'Failed to start follow mode', 'error');
+                return;
+            }}
+            showControlAlert('Follow mode started', 'success');
+            await refreshControlState();
+        }}
+
+        async function stopFollow() {{
+            const response = await fetch(API_BASE + '/control/follow/stop', {{ method: 'POST' }});
+            const data = await parseApiPayload(response);
+            if (!response.ok) {{
+                showControlAlert(data.message || 'Failed to stop follow mode', 'error');
+                return;
+            }}
+            showControlAlert('Follow mode stopped', 'success');
+            await refreshControlState();
+        }}
+
         function connectControlSocket() {{
             controlSocket = new WebSocket(WS_BASE + CONTROL_WS_PATH);
             controlSocket.onopen = () => {{
@@ -630,6 +670,13 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 }}
                 if (typeof data.max_angular_speed === 'number') {{
                     controlMaxAngular = data.max_angular_speed;
+                }}
+
+                const followResponse = await fetch(API_BASE + '/control/follow/state');
+                if (followResponse.ok) {{
+                    const followData = await followResponse.json();
+                    document.getElementById('followEnabledValue').textContent = followData.enabled ? 'yes' : 'no';
+                    document.getElementById('followLostValue').textContent = followData.lost_target ? 'yes' : 'no';
                 }}
             }} catch (error) {{
                 // Keep UI responsive when API is restarting.


### PR DESCRIPTION
Closes #24

## Acceptance Criteria Checklist
- [x] Follow command from UI
- [x] Smooth velocity control
- [x] Lost target handling
- [x] E-Stop overrides instantly

## Summary
Implements Follow Behavior v1 by adding a dedicated follow controller, API endpoints, and UI controls that drive autonomous follow commands through the safety arbiter.

## What Changed
- Added follow controller logic in `src/control/follow_behavior.py` with:
  - target observation ingestion
  - proportional follow control (area + horizontal offset)
  - exponential smoothing for velocity output
  - lost-target timeout that forces immediate zero motion
- Integrated follow runtime loop in `src/api/main.py`:
  - `POST /control/follow/start`
  - `POST /control/follow/stop`
  - `GET /control/follow/state`
  - `POST /control/follow/observation`
- Added Teleoperation UI controls in `src/ui/main.py` for start/stop follow and status indicators
- Updated OpenAPI spec in `docs/api/OPENAPI.yaml`
- Updated control/UI docs:
  - `docs/control/ARBITECTURE.md`
  - `docs/ui/UI_BEHAVIOR.md`

## Tests
- `python3 -m pytest src/control/test_follow_behavior.py src/control/test_arbiter.py src/api/test_follow_api.py src/api/test_control_api.py -q`

## Required Docs Reviewed
- docs/init/VISION_AND_FOLLOW_SPEC.md
- docs/init/CONTROL_AND_SAFETY_SPEC.md
- docs/control/ARBITECTURE.md

## Questions/Assumptions
- Assumption: vision runtime (or UI selection layer) provides target observations to `/control/follow/observation`; this PR focuses on safe follow control and orchestration, not multi-target selection UX.
