### PR TITLE
(#25) Implement Voice v1 TTS

### DIFF
--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -789,13 +789,30 @@ paths:
   /voice/tts:
     post:
       summary: Text to speech
+      description: Server-side OpenAI TTS synthesis for UI audible feedback.
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              required: [text]
               properties:
-                text: { type: string }
+                text:
+                  type: string
+                  description: Text to synthesize (max 1000 chars)
+                voice:
+                  type: string
+                  description: Optional OpenAI voice name
       responses:
         '200':
           description: Audio stream returned
+          content:
+            audio/mpeg:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid request (for example missing text)
+        '503':
+          description: TTS provider unavailable or not configured

--- a/docs/ui/UI_BEHAVIOR.md
+++ b/docs/ui/UI_BEHAVIOR.md
@@ -38,6 +38,11 @@
 - FPS is visible in the UI during streaming
 - On stream error (for example API restart), UI automatically reconnects
 
+## Voice Settings Page
+- UI allows TTS preview text entry and playback test via POST /voice/tts
+- UI exposes volume slider and mute toggle for TTS playback
+- TTS volume/mute controls affect browser playback, not motor/safety control
+
 ## System Status Page
 - UI displays expanded health data from GET /health (uptime, temperature, memory, disk, services)
 - UI refreshes system status automatically while page is open

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -59,6 +59,14 @@ except ImportError:
     COMMAND_PARSER_AVAILABLE = False
     logging.warning("Command intent parser not available")
 
+try:
+    from tts_provider import OpenAITTSProvider, TTSError
+    TTS_AVAILABLE = True
+except ImportError:
+    TTS_AVAILABLE = False
+    TTSError = Exception
+    logging.warning("TTS provider not available")
+
 
 SYSTEM_ACTION_DELAY_SECONDS = 0.5
 MJPEG_BOUNDARY = 'frame'
@@ -508,6 +516,10 @@ class APIHandler(BaseHTTPRequestHandler):
     _command_parser: Optional['CommandIntentParser'] = None
     _command_parser_lock = threading.Lock()
 
+    # Global TTS provider instance (shared across requests)
+    _tts_provider: Optional['OpenAITTSProvider'] = None
+    _tts_provider_lock = threading.Lock()
+
     # Global control arbiter for teleoperation
     _control_arbiter: Optional[ControlArbiter] = None
     _control_lock = threading.Lock()
@@ -548,6 +560,22 @@ class APIHandler(BaseHTTPRequestHandler):
                 cls._command_parser = CommandIntentParser()
                 logging.info("Command intent parser initialized")
             return cls._command_parser
+
+    @classmethod
+    def get_tts_provider(cls):
+        """Get or create TTS provider instance (singleton pattern)."""
+        if not TTS_AVAILABLE:
+            return None
+
+        api_key = os.environ.get('OPENAI_API_KEY', '').strip()
+        if not api_key:
+            return None
+
+        with cls._tts_provider_lock:
+            if cls._tts_provider is None:
+                cls._tts_provider = OpenAITTSProvider(api_key=api_key)
+                logging.info("OpenAI TTS provider initialized")
+            return cls._tts_provider
 
     @classmethod
     def get_control_arbiter(cls):
@@ -768,6 +796,8 @@ class APIHandler(BaseHTTPRequestHandler):
             self.handle_stt()
         elif self.path == '/voice/command':
             self.handle_voice_command()
+        elif self.path == '/voice/tts':
+            self.handle_voice_tts()
         else:
             self.send_error(404, "Not Found")
 
@@ -1429,6 +1459,53 @@ class APIHandler(BaseHTTPRequestHandler):
         except Exception as e:
             logging.error(f"Voice command endpoint error: {str(e)}")
             self.send_error(500, "Internal Server Error: Unable to parse voice command")
+
+    def handle_voice_tts(self):
+        """Handle POST /voice/tts endpoint."""
+        try:
+            provider = self.get_tts_provider()
+            if provider is None:
+                self.send_error(503, "TTS service not configured")
+                return
+
+            content_length = int(self.headers.get('Content-Length', 0))
+            if content_length <= 0:
+                self.send_error(400, "Request body is required")
+                return
+
+            body = self.rfile.read(content_length).decode('utf-8')
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                self.send_error(400, "Invalid JSON in request body")
+                return
+
+            text = str(payload.get('text', '')).strip()
+            if not text:
+                self.send_error(400, "Missing required field: text")
+                return
+            if len(text) > 1000:
+                self.send_error(400, "Text is too long (max 1000 characters)")
+                return
+
+            voice = str(payload.get('voice', 'alloy')).strip() or 'alloy'
+
+            try:
+                audio_bytes = provider.synthesize(text, voice=voice)
+            except TTSError as exc:
+                logging.error("TTS synthesis error: %s", exc)
+                self.send_error(503, str(exc))
+                return
+
+            self.send_response(200)
+            self.send_header('Content-Type', 'audio/mpeg')
+            self.send_header('Cache-Control', 'no-store')
+            self.send_header('Content-Length', str(len(audio_bytes)))
+            self.end_headers()
+            self.wfile.write(audio_bytes)
+        except Exception as exc:
+            logging.error("TTS endpoint error: %s", exc)
+            self.send_error(500, "Internal Server Error: Unable to synthesize speech")
 
 
 def main():

--- a/src/api/test_tts_api.py
+++ b/src/api/test_tts_api.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Integration tests for TTS API endpoint."""
+
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from http.server import HTTPServer
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from main import APIHandler
+
+
+class _FakeTTSProvider:
+    def __init__(self, should_fail: bool = False):
+        self.should_fail = should_fail
+
+    def synthesize(self, text: str, *, voice: str) -> bytes:
+        if self.should_fail:
+            raise RuntimeError('provider failed')
+        return b'ID3FAKE-MP3'
+
+
+class TestTTSEndpoint(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['API_HOST'] = 'localhost'
+        os.environ['API_PORT'] = '18086'
+        os.environ['OPENAI_API_KEY'] = 'test-key-123'
+
+        APIHandler._tts_provider = _FakeTTSProvider()
+
+        cls.server = HTTPServer(('localhost', 18086), APIHandler)
+        cls.server_thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.server_thread.start()
+        time.sleep(0.5)
+        cls.base_url = 'http://localhost:18086'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server_thread.join(timeout=5)
+
+    def _post_json(self, path, payload):
+        req = urllib.request.Request(
+            f'{self.base_url}{path}',
+            data=json.dumps(payload).encode('utf-8'),
+            method='POST',
+            headers={'Content-Type': 'application/json'},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as response:
+                return response.status, response.headers, response.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.headers, exc.read()
+
+    def test_tts_missing_text(self):
+        status, _headers, _body = self._post_json('/voice/tts', {'voice': 'alloy'})
+        self.assertEqual(status, 400)
+
+    def test_tts_success_returns_audio(self):
+        status, headers, body = self._post_json('/voice/tts', {'text': 'hello world'})
+        self.assertEqual(status, 200)
+        self.assertEqual(headers.get('Content-Type'), 'audio/mpeg')
+        self.assertGreater(len(body), 0)
+
+    def test_tts_endpoint_exists_post_only(self):
+        req = urllib.request.Request(f'{self.base_url}/voice/tts', method='GET')
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            urllib.request.urlopen(req, timeout=5)
+        self.assertEqual(ctx.exception.code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -218,6 +218,22 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 <p class="info">Current wake word: <span id="currentWakeWord" class="current-value">Loading...</span></p>
                 <p class="info">The wake word must contain only ASCII characters and cannot be empty.</p>
             </div>
+
+            <div class="form-group">
+                <label for="ttsPreviewText">TTS Preview Text:</label>
+                <input type="text" id="ttsPreviewText" value="System ready." placeholder="Enter text to speak">
+                <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap; margin-top:10px;">
+                    <label for="ttsVolume">Volume</label>
+                    <input type="range" id="ttsVolume" min="0" max="100" value="80" oninput="updateTtsVolume()">
+                    <span id="ttsVolumeValue" class="current-value">80%</span>
+                    <label>
+                        <input type="checkbox" id="ttsMuted" onchange="updateTtsMute()">
+                        <span class="checkbox-label">Mute</span>
+                    </label>
+                    <button class="button button-secondary" onclick="previewTts()">Preview Speech</button>
+                </div>
+                <p class="info">Volume and mute controls affect UI playback of server-generated TTS audio.</p>
+            </div>
             
             <button class="button" onclick="saveWakeWordConfig()">Save Settings</button>
         </div>
@@ -326,6 +342,8 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         let controlMaxLinear = 0.5;
         let controlMaxAngular = 1.2;
         let videoReconnectTimer = null;
+        let ttsVolume = 0.8;
+        let ttsMuted = false;
 
         // Load current wake word configuration on page load
         async function loadWakeWordConfig() {{
@@ -399,6 +417,50 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 setTimeout(() => {{
                     alertDiv.style.display = 'none';
                 }}, 3000);
+            }}
+        }}
+
+        function updateTtsVolume() {{
+            const slider = document.getElementById('ttsVolume');
+            const pct = Math.max(0, Math.min(100, parseInt(slider.value, 10) || 0));
+            ttsVolume = pct / 100.0;
+            document.getElementById('ttsVolumeValue').textContent = pct + '%';
+        }}
+
+        function updateTtsMute() {{
+            ttsMuted = document.getElementById('ttsMuted').checked;
+        }}
+
+        async function previewTts() {{
+            const text = document.getElementById('ttsPreviewText').value.trim();
+            if (!text) {{
+                showAlert('Preview text cannot be empty', 'error');
+                return;
+            }}
+
+            try {{
+                const response = await fetch(API_BASE + '/voice/tts', {{
+                    method: 'POST',
+                    headers: {{ 'Content-Type': 'application/json' }},
+                    body: JSON.stringify({{ text: text }}),
+                }});
+
+                if (!response.ok) {{
+                    const message = await getApiErrorMessage(response, 'Failed to synthesize speech');
+                    showAlert(message, 'error');
+                    return;
+                }}
+
+                const audioBlob = await response.blob();
+                const audioUrl = URL.createObjectURL(audioBlob);
+                const audio = new Audio(audioUrl);
+                audio.volume = ttsVolume;
+                audio.muted = ttsMuted;
+                audio.onended = () => URL.revokeObjectURL(audioUrl);
+                await audio.play();
+                showAlert('Playing TTS preview', 'success');
+            }} catch (error) {{
+                showAlert('TTS preview failed: ' + error.message, 'error');
             }}
         }}
 
@@ -848,6 +910,8 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         // Load configuration when page loads
         window.addEventListener('DOMContentLoaded', () => {{
             loadWakeWordConfig();
+            updateTtsVolume();
+            updateTtsMute();
             loadVersionInfo();
             connectControlSocket();
             setupJoystick();

--- a/src/voice/README.md
+++ b/src/voice/README.md
@@ -23,6 +23,14 @@ Server-side STT endpoint that:
 - Returns JSON transcript
 - **Server-side API calls only** (no client-side API exposure)
 
+### Text-to-Speech (TTS)
+
+Provider abstraction and OpenAI-backed TTS synthesis:
+- `tts_provider.py` defines the provider contract and OpenAI implementation
+- `POST /voice/tts` synthesizes text to audio/mpeg
+- Requires `OPENAI_API_KEY` in `/etc/turbopi/config.env`
+- Designed for audible UI/system feedback only (no direct motor control path)
+
 ### Command Intent Parser (`command_intent.py`)
 
 Schema-based command parser that:
@@ -47,6 +55,9 @@ Voice functionality is integrated into the TurboPi API service with the followin
 
 **Command Parsing:**
 - `POST /voice/command` - Parse voice transcript into command intent for safety arbiter
+
+**Text-to-Speech:**
+- `POST /voice/tts` - Synthesize text to audio/mpeg for UI playback
 
 See `docs/api/OPENAPI.yaml` for full API specification.
 
@@ -76,6 +87,9 @@ WAKE_WORD_TIMEOUT=5           # Timeout in seconds after detection
 
 # STT Settings
 OPENAI_API_KEY=your-key-here  # Required for STT functionality
+
+# TTS Settings
+# Uses OPENAI_API_KEY via server-side requests
 ```
 
 ## Safety Guarantees
@@ -170,6 +184,12 @@ curl -X POST http://localhost:8080/voice/stt \
 curl -X POST http://localhost:8080/voice/command \
   -H "Content-Type: application/json" \
   -d '{"transcript": "follow the person"}'
+
+# Synthesize TTS audio
+curl -X POST http://localhost:8080/voice/tts \
+  -H "Content-Type: application/json" \
+  -d '{"text": "System ready."}' \
+  -o speech.mp3
 ```
 
 ## Testing

--- a/src/voice/tts_provider.py
+++ b/src/voice/tts_provider.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Text-to-speech provider abstraction and OpenAI implementation."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class TTSError(Exception):
+    """Raised when text-to-speech synthesis fails."""
+
+
+class TTSProvider(Protocol):
+    """Protocol for pluggable TTS providers."""
+
+    def synthesize(self, text: str, *, voice: str) -> bytes:
+        """Synthesize text and return audio payload bytes."""
+
+
+@dataclass(frozen=True)
+class OpenAITTSProvider:
+    """OpenAI TTS implementation using server-side HTTP calls."""
+
+    api_key: str
+    model: str = 'gpt-4o-mini-tts'
+    response_format: str = 'mp3'
+
+    def synthesize(self, text: str, *, voice: str) -> bytes:
+        payload = {
+            'model': self.model,
+            'voice': voice,
+            'input': text,
+            'response_format': self.response_format,
+        }
+        req = urllib.request.Request(
+            'https://api.openai.com/v1/audio/speech',
+            data=json.dumps(payload).encode('utf-8'),
+            method='POST',
+            headers={
+                'Authorization': f'Bearer {self.api_key}',
+                'Content-Type': 'application/json',
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                return response.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code == 401:
+                raise TTSError('TTS authentication failed')
+            if exc.code == 429:
+                raise TTSError('TTS rate limit exceeded')
+            raise TTSError(f'TTS provider returned HTTP {exc.code}')
+        except urllib.error.URLError:
+            raise TTSError('TTS provider network unavailable')
+        except Exception as exc:
+            raise TTSError(f'TTS synthesis failed: {exc}')


### PR DESCRIPTION
Closes #25

## Acceptance Criteria Checklist
- [x] TTS provider abstraction
- [x] OpenAI TTS supported
- [x] UI controls for volume/mute

## Summary
Implements Voice v1 TTS with a provider abstraction, OpenAI-backed synthesis endpoint, and browser UI playback controls for preview volume and mute.

## What Changed
- Added provider abstraction and OpenAI implementation:
  - `src/voice/tts_provider.py`
- Added `POST /voice/tts` endpoint in API:
  - validates request payload (`text`, optional `voice`)
  - performs server-side OpenAI TTS call
  - returns `audio/mpeg`
  - safe error handling without key leakage
- Added API integration tests for TTS endpoint:
  - `src/api/test_tts_api.py`
- Added Voice Settings UI controls in `src/ui/main.py`:
  - preview text field
  - volume slider
  - mute toggle
  - preview playback button (`/voice/tts`)
- Updated API and behavior docs:
  - `docs/api/OPENAPI.yaml`
  - `docs/ui/UI_BEHAVIOR.md`
  - `src/voice/README.md`

## Tests
- `python3 -m pytest src/api/test_tts_api.py src/api/test_stt_api.py -q`
- `python3 -m pytest src/api/test_voice_command_api.py -q`
- `python3 -m pytest src/api/test_wake_word_api.py -q`
- `python3 -m pytest src/voice/test_command_intent.py src/voice/test_wake_word.py -q`

## Required Docs Reviewed
- docs/voice/WAKE_WORD.md
- docs/api/OPENAPI.yaml

## Questions/Assumptions
- Assumption: volume/mute controls are UI playback controls (browser-side) for TTS preview audio and do not require persistent server-side profile storage in this epic.
