### PR TITLE
Follow-up: resolve remaining PR #64 review comments

### DIFF
--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -815,5 +815,9 @@ paths:
                 format: binary
         '400':
           description: Invalid request (for example missing text)
+        '403':
+          description: Request origin is not allowed
+        '413':
+          description: Request payload too large
         '503':
           description: TTS provider unavailable or not configured

--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -800,6 +800,7 @@ paths:
               properties:
                 text:
                   type: string
+                  maxLength: 1000
                   description: Text to synthesize (max 1000 chars)
                 voice:
                   type: string

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1468,9 +1468,21 @@ class APIHandler(BaseHTTPRequestHandler):
                 self.send_error(503, "TTS service not configured")
                 return
 
-            content_length = int(self.headers.get('Content-Length', 0))
+            content_length_header = self.headers.get('Content-Length')
+            if content_length_header is None:
+                content_length = 0
+            else:
+                try:
+                    content_length = int(content_length_header)
+                except (TypeError, ValueError):
+                    self.send_error(400, "Invalid Content-Length header: must be an integer")
+                    return
+
             if content_length <= 0:
                 self.send_error(400, "Request body is required")
+                return
+            if content_length > (16 * 1024):
+                self.send_error(413, "TTS request too large")
                 return
 
             body = self.rfile.read(content_length).decode('utf-8')
@@ -1494,7 +1506,11 @@ class APIHandler(BaseHTTPRequestHandler):
                 audio_bytes = provider.synthesize(text, voice=voice)
             except TTSError as exc:
                 logging.error("TTS synthesis error: %s", exc)
-                self.send_error(503, str(exc))
+                self.send_error(503, "TTS provider temporarily unavailable")
+                return
+            except Exception as exc:
+                logging.error("Unexpected TTS provider error: %s", exc)
+                self.send_error(503, "TTS provider temporarily unavailable")
                 return
 
             self.send_response(200)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1463,6 +1463,9 @@ class APIHandler(BaseHTTPRequestHandler):
     def handle_voice_tts(self):
         """Handle POST /voice/tts endpoint."""
         try:
+            if not self._require_ui_origin():
+                return
+
             provider = self.get_tts_provider()
             if provider is None:
                 self.send_error(503, "TTS service not configured")
@@ -1509,7 +1512,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 self.send_error(503, "TTS provider temporarily unavailable")
                 return
             except Exception as exc:
-                logging.error("Unexpected TTS provider error: %s", exc)
+                logging.exception("Unexpected TTS provider error: %s", exc)
                 self.send_error(503, "TTS provider temporarily unavailable")
                 return
 

--- a/src/api/test_tts_api.py
+++ b/src/api/test_tts_api.py
@@ -32,6 +32,7 @@ class TestTTSEndpoint(unittest.TestCase):
         os.environ['API_HOST'] = 'localhost'
         os.environ['API_PORT'] = '18086'
         os.environ['OPENAI_API_KEY'] = 'test-key-123'
+        os.environ['UI_PORT'] = '8081'
 
         APIHandler._tts_provider = _FakeTTSProvider()
 
@@ -46,13 +47,15 @@ class TestTTSEndpoint(unittest.TestCase):
         cls.server.shutdown()
         cls.server_thread.join(timeout=5)
 
-    def _post_json(self, path, payload):
+    def _post_json(self, path, payload, with_origin=True):
         req = urllib.request.Request(
             f'{self.base_url}{path}',
             data=json.dumps(payload).encode('utf-8'),
             method='POST',
             headers={'Content-Type': 'application/json'},
         )
+        if with_origin:
+            req.add_header('Origin', 'http://localhost:8081')
         try:
             with urllib.request.urlopen(req, timeout=5) as response:
                 return response.status, response.headers, response.read()
@@ -73,11 +76,22 @@ class TestTTSEndpoint(unittest.TestCase):
         status, _headers, _body = self._post_json('/voice/tts', {'text': 'x' * 1001})
         self.assertEqual(status, 400)
 
+    def test_tts_oversized_payload_returns_413(self):
+        status, _headers, _body = self._post_json('/voice/tts', {'text': 'x' * 20000})
+        self.assertEqual(status, 413)
+
+    def test_tts_requires_ui_origin(self):
+        status, _headers, _body = self._post_json('/voice/tts', {'text': 'hello world'}, with_origin=False)
+        self.assertEqual(status, 403)
+
     def test_tts_provider_failure_returns_503(self):
+        original_provider = APIHandler._tts_provider
         APIHandler._tts_provider = _FakeTTSProvider(should_fail=True)
-        status, _headers, _body = self._post_json('/voice/tts', {'text': 'hello world'})
-        self.assertEqual(status, 503)
-        APIHandler._tts_provider = _FakeTTSProvider()
+        try:
+            status, _headers, _body = self._post_json('/voice/tts', {'text': 'hello world'})
+            self.assertEqual(status, 503)
+        finally:
+            APIHandler._tts_provider = original_provider
 
     def test_tts_endpoint_exists_post_only(self):
         req = urllib.request.Request(f'{self.base_url}/voice/tts', method='GET')

--- a/src/api/test_tts_api.py
+++ b/src/api/test_tts_api.py
@@ -69,6 +69,16 @@ class TestTTSEndpoint(unittest.TestCase):
         self.assertEqual(headers.get('Content-Type'), 'audio/mpeg')
         self.assertGreater(len(body), 0)
 
+    def test_tts_text_too_long(self):
+        status, _headers, _body = self._post_json('/voice/tts', {'text': 'x' * 1001})
+        self.assertEqual(status, 400)
+
+    def test_tts_provider_failure_returns_503(self):
+        APIHandler._tts_provider = _FakeTTSProvider(should_fail=True)
+        status, _headers, _body = self._post_json('/voice/tts', {'text': 'hello world'})
+        self.assertEqual(status, 503)
+        APIHandler._tts_provider = _FakeTTSProvider()
+
     def test_tts_endpoint_exists_post_only(self):
         req = urllib.request.Request(f'{self.base_url}/voice/tts', method='GET')
         with self.assertRaises(urllib.error.HTTPError) as ctx:

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -438,6 +438,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 return;
             }}
 
+            let audioUrl = null;
             try {{
                 const response = await fetch(API_BASE + '/voice/tts', {{
                     method: 'POST',
@@ -452,7 +453,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 }}
 
                 const audioBlob = await response.blob();
-                const audioUrl = URL.createObjectURL(audioBlob);
+                audioUrl = URL.createObjectURL(audioBlob);
                 const audio = new Audio(audioUrl);
                 audio.volume = ttsVolume;
                 audio.muted = ttsMuted;
@@ -461,6 +462,9 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 await audio.play();
                 showAlert('Playing TTS preview', 'success');
             }} catch (error) {{
+                if (audioUrl) {{
+                    URL.revokeObjectURL(audioUrl);
+                }}
                 showAlert('TTS preview failed: ' + error.message, 'error');
             }}
         }}

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -457,6 +457,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 audio.volume = ttsVolume;
                 audio.muted = ttsMuted;
                 audio.onended = () => URL.revokeObjectURL(audioUrl);
+                audio.onerror = () => URL.revokeObjectURL(audioUrl);
                 await audio.play();
                 showAlert('Playing TTS preview', 'success');
             }} catch (error) {{

--- a/src/voice/tts_provider.py
+++ b/src/voice/tts_provider.py
@@ -54,8 +54,8 @@ class OpenAITTSProvider:
                 raise TTSError('TTS authentication failed')
             if exc.code == 429:
                 raise TTSError('TTS rate limit exceeded')
-            raise TTSError(f'TTS provider returned HTTP {exc.code}')
+            raise TTSError('TTS provider temporarily unavailable')
         except urllib.error.URLError:
-            raise TTSError('TTS provider network unavailable')
-        except Exception as exc:
-            raise TTSError(f'TTS synthesis failed: {exc}')
+            raise TTSError('TTS provider temporarily unavailable')
+        except Exception:
+            raise TTSError('TTS provider temporarily unavailable')

--- a/src/voice/tts_provider.py
+++ b/src/voice/tts_provider.py
@@ -51,11 +51,11 @@ class OpenAITTSProvider:
                 return response.read()
         except urllib.error.HTTPError as exc:
             if exc.code == 401:
-                raise TTSError('TTS authentication failed')
+                raise TTSError('TTS authentication failed') from exc
             if exc.code == 429:
-                raise TTSError('TTS rate limit exceeded')
-            raise TTSError('TTS provider temporarily unavailable')
-        except urllib.error.URLError:
-            raise TTSError('TTS provider temporarily unavailable')
-        except Exception:
-            raise TTSError('TTS provider temporarily unavailable')
+                raise TTSError('TTS rate limit exceeded') from exc
+            raise TTSError('TTS provider temporarily unavailable') from exc
+        except urllib.error.URLError as exc:
+            raise TTSError('TTS provider temporarily unavailable') from exc
+        except Exception as exc:
+            raise TTSError('TTS provider temporarily unavailable') from exc


### PR DESCRIPTION
Addresses unresolved review threads from #64.

## What this fixes
- Hardened `/voice/tts` Content-Length parsing and request size limits.
- Sanitized TTS provider/client error responses to avoid leaking internal/provider details.
- Added `maxLength: 1000` for `/voice/tts` request schema in OpenAPI.
- Improved blob URL cleanup in UI TTS preview playback error path.
- Added missing TTS tests for max-length validation and provider-failure 503 behavior.

## Tests
- python3 -m pytest src/api/test_tts_api.py -q
- python3 -m pytest src/api/test_stt_api.py -q
- python3 -m pytest src/api/test_wake_word_api.py -q
- python3 -m pytest src/api/test_voice_command_api.py -q
