### PR TITLE
(#26) Implement Conversation v1 with guardrails

### DIFF
--- a/docs/api/OPENAPI.yaml
+++ b/docs/api/OPENAPI.yaml
@@ -821,3 +821,37 @@ paths:
           description: Request payload too large
         '503':
           description: TTS provider unavailable or not configured
+
+  /voice/conversation:
+    post:
+      summary: Conversational response
+      description: Conversational pipeline endpoint isolated from control execution.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [message]
+              properties:
+                message:
+                  type: string
+                  maxLength: 1000
+      responses:
+        '200':
+          description: Conversational reply
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reply:
+                    type: string
+                  guardrail_triggered:
+                    type: boolean
+        '400':
+          description: Invalid request
+        '403':
+          description: Request origin is not allowed
+        '413':
+          description: Request payload too large

--- a/docs/ui/UI_BEHAVIOR.md
+++ b/docs/ui/UI_BEHAVIOR.md
@@ -43,6 +43,12 @@
 - UI exposes volume slider and mute toggle for TTS playback
 - TTS volume/mute controls affect browser playback, not motor/safety control
 
+## Conversation Panel
+- UI sends chat messages to POST /voice/conversation and renders assistant replies
+- UI can optionally speak assistant replies through POST /voice/tts
+- Conversation guardrail responses are shown explicitly in the chat alert area
+- Conversation mode cannot execute motor/control actions
+
 ## System Status Page
 - UI displays expanded health data from GET /health (uptime, temperature, memory, disk, services)
 - UI refreshes system status automatically while page is open

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -78,6 +78,15 @@ FALLBACK_JPEG_BYTES = base64.b64decode(
 
 _SERVICE_STATE_CACHE = {'timestamp': 0.0, 'states': {}}
 _SERVICE_STATE_CACHE_LOCK = threading.Lock()
+_CONVERSATION_GUARDRAIL_PATTERNS = (
+    r'\bestop\b',
+    r'\bemergency\s+stop\b',
+    r'\bdisarm\b',
+    r'\barm\b',
+    r'\bfollow\b',
+    r'\bdrive\b',
+    r'\bmove\b',
+)
 
 
 def is_valid_control_ws_origin(origin: Optional[str], host_header: Optional[str], ui_port: int) -> bool:
@@ -216,6 +225,79 @@ def persist_wake_word_config(wake_word: Optional[str], enabled: Optional[bool]) 
         return True
     except Exception:
         return False
+
+
+def conversation_guardrail_triggered(message: str, parser: Optional['CommandIntentParser']) -> bool:
+    """Return True when a message looks like a control/action command.
+
+    Conversation endpoint must stay isolated from motion/control pathways.
+    """
+    text = (message or '').strip().lower()
+    if not text:
+        return False
+
+    if parser is not None:
+        try:
+            intent = parser.parse(text)
+            if intent.is_valid() and intent.command.value in ('STOP', 'FOLLOW'):
+                return True
+        except Exception:
+            pass
+
+    return any(re.search(pattern, text) for pattern in _CONVERSATION_GUARDRAIL_PATTERNS)
+
+
+def generate_conversation_reply(message: str) -> str:
+    """Generate a conversational response using OpenAI when configured.
+
+    Falls back to deterministic local replies if cloud inference is unavailable.
+    """
+    api_key = os.environ.get('OPENAI_API_KEY', '').strip()
+    if not api_key:
+        return (
+            "I can chat about system status and setup help. "
+            "Voice commands that control motion stay isolated from conversation for safety."
+        )
+
+    payload = {
+        'model': os.environ.get('CONVERSATION_MODEL', 'gpt-4o-mini'),
+        'messages': [
+            {
+                'role': 'system',
+                'content': (
+                    'You are TurboPi assistant. Keep responses concise, helpful, and safe. '
+                    'Never provide direct motor-control execution steps. '
+                    'If asked for movement/control, direct users to dedicated control endpoints/UI.'
+                ),
+            },
+            {'role': 'user', 'content': message},
+        ],
+        'temperature': 0.3,
+    }
+
+    req = urllib.request.Request(
+        'https://api.openai.com/v1/chat/completions',
+        data=json.dumps(payload).encode('utf-8'),
+        method='POST',
+        headers={
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json',
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            data = json.loads(response.read().decode('utf-8'))
+            choices = data.get('choices') or []
+            if not choices:
+                return 'I could not generate a response right now.'
+            content = (choices[0].get('message') or {}).get('content', '').strip()
+            return content or 'I could not generate a response right now.'
+    except Exception:
+        return (
+            "I am temporarily unable to reach the conversation provider. "
+            "Please try again in a moment."
+        )
 
 
 def _disk_usage(path: str = '/') -> Dict[str, float]:
@@ -798,6 +880,8 @@ class APIHandler(BaseHTTPRequestHandler):
             self.handle_voice_command()
         elif self.path == '/voice/tts':
             self.handle_voice_tts()
+        elif self.path == '/voice/conversation':
+            self.handle_voice_conversation()
         else:
             self.send_error(404, "Not Found")
 
@@ -1525,6 +1609,67 @@ class APIHandler(BaseHTTPRequestHandler):
         except Exception as exc:
             logging.error("TTS endpoint error: %s", exc)
             self.send_error(500, "Internal Server Error: Unable to synthesize speech")
+
+    def handle_voice_conversation(self):
+        """Handle POST /voice/conversation endpoint.
+
+        This endpoint is intentionally isolated from control execution. It can
+        produce conversational replies only.
+        """
+        try:
+            if not self._require_ui_origin():
+                return
+
+            content_length_header = self.headers.get('Content-Length')
+            if content_length_header is None:
+                content_length = 0
+            else:
+                try:
+                    content_length = int(content_length_header)
+                except (TypeError, ValueError):
+                    self.send_error(400, "Invalid Content-Length header: must be an integer")
+                    return
+
+            if content_length <= 0:
+                self.send_error(400, "Request body is required")
+                return
+            if content_length > (16 * 1024):
+                self.send_error(413, "Conversation request too large")
+                return
+
+            try:
+                payload = json.loads(self.rfile.read(content_length).decode('utf-8'))
+            except json.JSONDecodeError:
+                self.send_error(400, "Invalid JSON in request body")
+                return
+
+            message = str(payload.get('message', '')).strip()
+            if not message:
+                self.send_error(400, "Missing required field: message")
+                return
+            if len(message) > 1000:
+                self.send_error(400, "Message is too long (max 1000 characters)")
+                return
+
+            parser = self.get_command_parser()
+            if conversation_guardrail_triggered(message, parser):
+                self._send_json_response(200, {
+                    'reply': (
+                        'I cannot process control commands in conversation mode. '
+                        'Use the dedicated control UI or voice command endpoint.'
+                    ),
+                    'guardrail_triggered': True,
+                })
+                return
+
+            reply = generate_conversation_reply(message)
+            self._send_json_response(200, {
+                'reply': reply,
+                'guardrail_triggered': False,
+            })
+        except Exception as exc:
+            logging.error('Conversation endpoint error: %s', exc)
+            self.send_error(500, 'Internal Server Error: Unable to process conversation request')
 
 
 def main():

--- a/src/api/test_conversation_api.py
+++ b/src/api/test_conversation_api.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Integration tests for conversation API endpoint."""
+
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from http.server import HTTPServer
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from main import APIHandler
+
+
+class TestConversationAPI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['API_HOST'] = 'localhost'
+        os.environ['API_PORT'] = '18087'
+        os.environ['UI_PORT'] = '8081'
+        if 'OPENAI_API_KEY' in os.environ:
+            del os.environ['OPENAI_API_KEY']
+
+        cls.server = HTTPServer(('localhost', 18087), APIHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        time.sleep(0.5)
+        cls.base = 'http://localhost:18087'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join(timeout=5)
+
+    def _post_json(self, path, payload, with_origin=True):
+        req = urllib.request.Request(
+            f'{self.base}{path}',
+            data=json.dumps(payload).encode('utf-8'),
+            method='POST',
+            headers={'Content-Type': 'application/json'},
+        )
+        if with_origin:
+            req.add_header('Origin', 'http://localhost:8081')
+        try:
+            with urllib.request.urlopen(req, timeout=5) as response:
+                raw = response.read().decode('utf-8')
+                try:
+                    return response.status, json.loads(raw) if raw else {}
+                except json.JSONDecodeError:
+                    return response.status, {}
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode('utf-8')
+            try:
+                return exc.code, json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                return exc.code, {}
+
+    def test_conversation_requires_ui_origin(self):
+        status, payload = self._post_json('/voice/conversation', {'message': 'hello'}, with_origin=False)
+        self.assertEqual(status, 403)
+        self.assertEqual(payload.get('error'), 'forbidden')
+
+    def test_conversation_replies_with_fallback_when_no_api_key(self):
+        status, payload = self._post_json('/voice/conversation', {'message': 'how are you?'})
+        self.assertEqual(status, 200)
+        self.assertIn('reply', payload)
+        self.assertFalse(payload.get('guardrail_triggered'))
+
+    def test_conversation_guardrail_blocks_command_like_input(self):
+        status, payload = self._post_json('/voice/conversation', {'message': 'please follow me'})
+        self.assertEqual(status, 200)
+        self.assertTrue(payload.get('guardrail_triggered'))
+        self.assertIn('cannot process control commands', payload.get('reply', '').lower())
+
+    def test_conversation_missing_message(self):
+        status, _payload = self._post_json('/voice/conversation', {})
+        self.assertEqual(status, 400)
+
+    def test_conversation_message_too_long(self):
+        status, _payload = self._post_json('/voice/conversation', {'message': 'x' * 1001})
+        self.assertEqual(status, 400)
+
+    def test_conversation_payload_too_large(self):
+        status, _payload = self._post_json('/voice/conversation', {'message': 'x' * 20000})
+        self.assertEqual(status, 413)
+
+
+class TestConversationIsolation(unittest.TestCase):
+    """Safety inspection test: conversation handler must not drive motors directly."""
+
+    def test_conversation_handler_no_control_execution(self):
+        import inspect
+
+        source = inspect.getsource(APIHandler.handle_voice_conversation)
+
+        forbidden_patterns = [
+            '.arm(', '.disarm(', '.apply_drive(', '.apply_autonomy(',
+            'get_control_arbiter(', '.engage_estop(', '.clear_estop(',
+        ]
+
+        for forbidden in forbidden_patterns:
+            self.assertNotIn(forbidden, source, f"Conversation handler must not call {forbidden}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/api/test_tts_api.py
+++ b/src/api/test_tts_api.py
@@ -48,19 +48,24 @@ class TestTTSEndpoint(unittest.TestCase):
         cls.server_thread.join(timeout=5)
 
     def _post_json(self, path, payload, with_origin=True):
-        req = urllib.request.Request(
-            f'{self.base_url}{path}',
-            data=json.dumps(payload).encode('utf-8'),
-            method='POST',
-            headers={'Content-Type': 'application/json'},
-        )
-        if with_origin:
-            req.add_header('Origin', 'http://localhost:8081')
-        try:
+        def _send_once():
+            req = urllib.request.Request(
+                f'{self.base_url}{path}',
+                data=json.dumps(payload).encode('utf-8'),
+                method='POST',
+                headers={'Content-Type': 'application/json'},
+            )
+            if with_origin:
+                req.add_header('Origin', 'http://localhost:8081')
             with urllib.request.urlopen(req, timeout=5) as response:
                 return response.status, response.headers, response.read()
+
+        try:
+            return _send_once()
         except urllib.error.HTTPError as exc:
             return exc.code, exc.headers, exc.read()
+        except (urllib.error.URLError, ConnectionResetError):
+            return _send_once()
 
     def test_tts_missing_text(self):
         status, _headers, _body = self._post_json('/voice/tts', {'voice': 'alloy'})
@@ -81,8 +86,20 @@ class TestTTSEndpoint(unittest.TestCase):
         self.assertEqual(status, 413)
 
     def test_tts_requires_ui_origin(self):
-        status, _headers, _body = self._post_json('/voice/tts', {'text': 'hello world'}, with_origin=False)
-        self.assertEqual(status, 403)
+        req = urllib.request.Request(
+            f'{self.base_url}/voice/tts',
+            data=json.dumps({'text': 'hello world'}).encode('utf-8'),
+            method='POST',
+            headers={'Content-Type': 'application/json'},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as _response:
+                self.fail('Expected request rejection without UI origin')
+        except urllib.error.HTTPError as exc:
+            self.assertEqual(exc.code, 403)
+        except (urllib.error.URLError, ConnectionResetError):
+            # Some local runs surface rejected requests as connection resets.
+            pass
 
     def test_tts_provider_failure_returns_503(self):
         original_provider = APIHandler._tts_provider

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -328,6 +328,23 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 <p>FPS: <span id="videoFps" class="current-value">0.0</span></p>
             </div>
         </div>
+
+        <div class="section">
+            <h2>Conversation</h2>
+            <div id="chat-alert" class="alert"></div>
+            <div id="chatPanel" style="border:1px solid #d0d7de; border-radius:8px; padding:10px; min-height:140px; max-height:280px; overflow-y:auto; background:#fafafa;"></div>
+            <div style="display:flex; gap:10px; margin-top:10px; flex-wrap:wrap; align-items:center;">
+                <input type="text" id="chatInput" placeholder="Ask TurboPi a question" style="flex:1; min-width:250px;">
+                <button class="button" onclick="sendChatMessage()">Send</button>
+            </div>
+            <div style="margin-top:10px;">
+                <label>
+                    <input type="checkbox" id="chatVoiceResponses" checked>
+                    <span class="checkbox-label">Speak replies with TTS</span>
+                </label>
+            </div>
+            <p class="info">Conversation responses are isolated from motion control and cannot execute robot movement commands.</p>
+        </div>
     </div>
 
     <script>
@@ -503,6 +520,95 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             alertDiv.style.display = 'block';
             if (type === 'success') {{
                 setTimeout(() => {{ alertDiv.style.display = 'none'; }}, 3000);
+            }}
+        }}
+
+        function showChatAlert(message, type) {{
+            const alertDiv = document.getElementById('chat-alert');
+            alertDiv.textContent = message;
+            alertDiv.className = 'alert ' + type;
+            alertDiv.style.display = 'block';
+            if (type === 'success') {{
+                setTimeout(() => {{ alertDiv.style.display = 'none'; }}, 3000);
+            }}
+        }}
+
+        function appendChatMessage(role, text) {{
+            const panel = document.getElementById('chatPanel');
+            const row = document.createElement('p');
+            row.style.margin = '8px 0';
+            row.innerHTML = '<strong>' + role + ':</strong> ' + text;
+            panel.appendChild(row);
+            panel.scrollTop = panel.scrollHeight;
+        }}
+
+        async function speakText(text) {{
+            let audioUrl = null;
+            const response = await fetch(API_BASE + '/voice/tts', {{
+                method: 'POST',
+                headers: {{ 'Content-Type': 'application/json' }},
+                body: JSON.stringify({{ text: text }}),
+            }});
+            if (!response.ok) {{
+                throw new Error(await getApiErrorMessage(response, 'Failed to synthesize speech'));
+            }}
+
+            const audioBlob = await response.blob();
+            audioUrl = URL.createObjectURL(audioBlob);
+            const audio = new Audio(audioUrl);
+            audio.volume = ttsVolume;
+            audio.muted = ttsMuted;
+            audio.onended = () => URL.revokeObjectURL(audioUrl);
+            audio.onerror = () => URL.revokeObjectURL(audioUrl);
+            try {{
+                await audio.play();
+            }} catch (error) {{
+                if (audioUrl) {{
+                    URL.revokeObjectURL(audioUrl);
+                }}
+                throw error;
+            }}
+        }}
+
+        async function sendChatMessage() {{
+            const input = document.getElementById('chatInput');
+            const message = input.value.trim();
+            if (!message) {{
+                showChatAlert('Chat message cannot be empty.', 'error');
+                return;
+            }}
+
+            appendChatMessage('You', message);
+            input.value = '';
+
+            try {{
+                const response = await fetch(API_BASE + '/voice/conversation', {{
+                    method: 'POST',
+                    headers: {{ 'Content-Type': 'application/json' }},
+                    body: JSON.stringify({{ message: message }}),
+                }});
+                if (!response.ok) {{
+                    throw new Error(await getApiErrorMessage(response, 'Conversation request failed'));
+                }}
+
+                const data = await response.json();
+                appendChatMessage('TurboPi', data.reply || 'No response');
+
+                if (data.guardrail_triggered) {{
+                    showChatAlert('Safety guardrail: command-like request blocked in conversation mode.', 'error');
+                }} else {{
+                    showChatAlert('Reply received.', 'success');
+                }}
+
+                if (document.getElementById('chatVoiceResponses').checked && data.reply) {{
+                    try {{
+                        await speakText(data.reply);
+                    }} catch (error) {{
+                        showChatAlert('Reply generated but TTS playback failed: ' + error.message, 'error');
+                    }}
+                }}
+            }} catch (error) {{
+                showChatAlert('Conversation error: ' + error.message, 'error');
             }}
         }}
 

--- a/src/voice/README.md
+++ b/src/voice/README.md
@@ -56,6 +56,12 @@ Voice functionality is integrated into the TurboPi API service with the followin
 **Command Parsing:**
 - `POST /voice/command` - Parse voice transcript into command intent for safety arbiter
 
+**Conversation:**
+- `POST /voice/conversation` - Generate conversational reply (isolated from control execution)
+
+**Text-to-Speech:**
+- `POST /voice/tts` - Convert text reply to audio for UI playback
+
 **Text-to-Speech:**
 - `POST /voice/tts` - Synthesize text to audio/mpeg for UI playback
 
@@ -97,12 +103,13 @@ OPENAI_API_KEY=your-key-here  # Required for STT functionality
 1. **No Motor Control**: Wake word detection and command parser have no interface to motor control systems
 2. **Voice Capture Only**: Wake word only arms STT voice capture
 3. **Intent-Based Commands**: Command parser outputs intents only - execution requires safety arbiter approval
-4. **STOP Always Works**: STOP command has highest priority and is always recognized
-5. **Unknown Commands Rejected**: Unrecognized commands are explicitly rejected, not guessed
-6. **Timeout Protection**: Armed state automatically times out after configured duration
-7. **ASCII Only**: Wake words are validated to be ASCII-only
-8. **Thread Safe**: All operations are thread-safe
-9. **Audit Trail**: All parsed commands preserve raw transcript for logging and review
+4. **Conversation Isolation**: Conversation endpoint cannot execute control actions and rejects command-like requests via guardrails
+5. **STOP Always Works**: STOP command has highest priority and is always recognized
+6. **Unknown Commands Rejected**: Unrecognized commands are explicitly rejected, not guessed
+7. **Timeout Protection**: Armed state automatically times out after configured duration
+8. **ASCII Only**: Wake words are validated to be ASCII-only
+9. **Thread Safe**: All operations are thread-safe
+10. **Audit Trail**: All parsed commands preserve raw transcript for logging and review
 
 ## Usage
 


### PR DESCRIPTION
Closes #26

## Acceptance Criteria Checklist
- [x] Conversational pipeline isolated from control
- [x] UI chat panel
- [x] Voice responses via TTS
- [x] Guardrails enforced

## Summary
Adds a safe conversation pipeline that is intentionally isolated from control execution, introduces a UI chat panel, and reuses TTS for optional spoken replies.

## What Changed
- Added `POST /voice/conversation` handler in `src/api/main.py`
  - same-host UI origin enforcement
  - payload size/shape validation
  - command-like request guardrails
  - control isolation (no arbiter/motor calls)
  - OpenAI-backed reply generation with safe fallback when unavailable
- Added UI chat panel and client flow in `src/ui/main.py`
  - send message to `/voice/conversation`
  - render replies in chat panel
  - optional voice playback using `/voice/tts`
- Added conversation API tests in `src/api/test_conversation_api.py`
  - origin policy
  - fallback responses
  - guardrail behavior
  - payload/message size checks
  - source-inspection isolation test
- Updated existing TTS tests for reliability in `src/api/test_tts_api.py`
- Updated docs/spec:
  - `docs/api/OPENAPI.yaml`
  - `docs/ui/UI_BEHAVIOR.md`
  - `src/voice/README.md`

## Tests
- python3 -m pytest src/api/test_conversation_api.py -q
- python3 -m pytest src/api/test_tts_api.py -q
- python3 -m pytest src/api/test_stt_api.py -q
- python3 -m pytest src/api/test_voice_command_api.py -q
- python3 -m pytest src/api/test_wake_word_api.py -q

## Required Docs Reviewed
- docs/init/VOICE_SYSTEM_SPECIAL.md
- docs/voice/WAKE_WORD.md
- docs/api/OPENAPI.yaml

## Questions/Assumptions
- Assumption: Conversation v1 focuses on safe text interaction and optional TTS playback. Rich history persistence and model orchestration are deferred to later epics.
