### PR TITLE
(#28) Add replay tests and 2D follow simulation

### DIFF
--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -14,16 +14,16 @@
 3. Simulation
 - 2D kinematic follow tests
 
+4. Hardware Smoke Tests
+- Motors stop
+- Camera frames
+- E-Stop latch
+
 ## Implemented Suites
 
 - Vision replay pipeline tests: `src/vision/test_replay_pipeline.py`
 - Voice command replay tests: `src/voice/test_replay_command_intent.py`
 - 2D follow behavior simulation tests: `src/control/test_follow_sim_2d.py`
-
-4. Hardware Smoke Tests
-- Motors stop
-- Camera frames
-- E-Stop latch
 
 ## CI Rules
 - Tests required for merge

--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -14,6 +14,12 @@
 3. Simulation
 - 2D kinematic follow tests
 
+## Implemented Suites
+
+- Vision replay pipeline tests: `src/vision/test_replay_pipeline.py`
+- Voice command replay tests: `src/voice/test_replay_command_intent.py`
+- 2D follow behavior simulation tests: `src/control/test_follow_sim_2d.py`
+
 4. Hardware Smoke Tests
 - Motors stop
 - Camera frames

--- a/src/control/follow_sim_2d.py
+++ b/src/control/follow_sim_2d.py
@@ -106,8 +106,10 @@ def run_follow_simulation_2d(
 
     pose = initial_pose
     history: List[SimulationStep] = []
+    previous_t_s: float | None = None
 
     for point in points:
+        step_dt_s = dt_s if previous_t_s is None else max(0.0, point.t_s - previous_t_s)
         observation = _target_observation_from_world(
             target_id=target_id,
             now_s=point.t_s,
@@ -126,10 +128,11 @@ def run_follow_simulation_2d(
         linear_mps = command.linear_mps if command is not None else 0.0
         angular_rps = command.angular_rps if command is not None else 0.0
 
-        yaw = pose.yaw_rad + (angular_rps * dt_s)
-        x = pose.x_m + (linear_mps * math.cos(yaw) * dt_s)
-        y = pose.y_m + (linear_mps * math.sin(yaw) * dt_s)
+        yaw = pose.yaw_rad + (angular_rps * step_dt_s)
+        x = pose.x_m + (linear_mps * math.cos(yaw) * step_dt_s)
+        y = pose.y_m + (linear_mps * math.sin(yaw) * step_dt_s)
         pose = Pose2D(x_m=x, y_m=y, yaw_rad=yaw)
+        previous_t_s = point.t_s
 
         history.append(
             SimulationStep(

--- a/src/control/follow_sim_2d.py
+++ b/src/control/follow_sim_2d.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Lightweight 2D simulation harness for follow behavior testing."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from control.follow_behavior import FollowBehavior, TargetObservation
+
+
+@dataclass(frozen=True)
+class Pose2D:
+    """Robot pose in a 2D plane."""
+
+    x_m: float
+    y_m: float
+    yaw_rad: float
+
+
+@dataclass(frozen=True)
+class SimulationStep:
+    """One simulation sample including command outputs."""
+
+    t_s: float
+    pose: Pose2D
+    linear_mps: float
+    angular_rps: float
+    observation_used: bool
+
+
+@dataclass(frozen=True)
+class TargetPoint:
+    """Target world position at a timestamp."""
+
+    t_s: float
+    x_m: float
+    y_m: float
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(value, maximum))
+
+
+def _target_observation_from_world(
+    *,
+    target_id: int,
+    now_s: float,
+    pose: Pose2D,
+    target_x_m: float,
+    target_y_m: float,
+    horizontal_fov_rad: float,
+    area_scale: float,
+    max_range_m: float,
+) -> TargetObservation | None:
+    """Project a world target into normalized follow observation space."""
+    dx = target_x_m - pose.x_m
+    dy = target_y_m - pose.y_m
+
+    # Transform world vector into robot frame.
+    forward = math.cos(pose.yaw_rad) * dx + math.sin(pose.yaw_rad) * dy
+    lateral = -math.sin(pose.yaw_rad) * dx + math.cos(pose.yaw_rad) * dy
+
+    distance = math.hypot(forward, lateral)
+    if forward <= 0.0 or distance > max_range_m:
+        return None
+
+    bearing = math.atan2(lateral, forward)
+    half_fov = horizontal_fov_rad / 2.0
+    if abs(bearing) > half_fov:
+        return None
+
+    # Map bearing [-half_fov, half_fov] to normalized [0, 1].
+    center_x = _clamp(0.5 + (bearing / horizontal_fov_rad), 0.0, 1.0)
+    area = _clamp(area_scale / max(distance * distance, 1e-6), 0.0, 1.0)
+
+    return TargetObservation(
+        target_id=target_id,
+        center_x=center_x,
+        area=area,
+        timestamp=now_s,
+    )
+
+
+def run_follow_simulation_2d(
+    *,
+    behavior: FollowBehavior,
+    target_track: Iterable[TargetPoint],
+    dt_s: float = 0.1,
+    initial_pose: Pose2D = Pose2D(x_m=0.0, y_m=0.0, yaw_rad=0.0),
+    target_id: int = 1,
+    horizontal_fov_rad: float = 1.2,
+    area_scale: float = 0.14,
+    max_range_m: float = 5.0,
+) -> List[SimulationStep]:
+    """Run follow behavior against a deterministic target trajectory."""
+    if dt_s <= 0.0:
+        raise ValueError('dt_s must be positive')
+
+    points = sorted(list(target_track), key=lambda p: p.t_s)
+    if not points:
+        return []
+
+    behavior.start(target_id=target_id)
+
+    pose = initial_pose
+    history: List[SimulationStep] = []
+
+    for point in points:
+        observation = _target_observation_from_world(
+            target_id=target_id,
+            now_s=point.t_s,
+            pose=pose,
+            target_x_m=point.x_m,
+            target_y_m=point.y_m,
+            horizontal_fov_rad=horizontal_fov_rad,
+            area_scale=area_scale,
+            max_range_m=max_range_m,
+        )
+
+        if observation is not None:
+            behavior.update_observation(observation)
+
+        command = behavior.next_command(now=point.t_s)
+        linear_mps = command.linear_mps if command is not None else 0.0
+        angular_rps = command.angular_rps if command is not None else 0.0
+
+        yaw = pose.yaw_rad + (angular_rps * dt_s)
+        x = pose.x_m + (linear_mps * math.cos(yaw) * dt_s)
+        y = pose.y_m + (linear_mps * math.sin(yaw) * dt_s)
+        pose = Pose2D(x_m=x, y_m=y, yaw_rad=yaw)
+
+        history.append(
+            SimulationStep(
+                t_s=point.t_s,
+                pose=pose,
+                linear_mps=linear_mps,
+                angular_rps=angular_rps,
+                observation_used=observation is not None,
+            )
+        )
+
+    return history

--- a/src/control/test_follow_sim_2d.py
+++ b/src/control/test_follow_sim_2d.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Unit tests for the 2D follow behavior simulation harness."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from control.follow_behavior import FollowBehavior
+from control.follow_sim_2d import Pose2D, TargetPoint, run_follow_simulation_2d
+
+
+class TestFollowSimulation2D(unittest.TestCase):
+    def test_robot_closes_distance_to_stationary_target(self):
+        behavior = FollowBehavior(smooth_alpha=0.8)
+        track = [TargetPoint(t_s=i * 0.1, x_m=2.0, y_m=0.4) for i in range(30)]
+
+        history = run_follow_simulation_2d(
+            behavior=behavior,
+            target_track=track,
+            dt_s=0.1,
+            initial_pose=Pose2D(x_m=0.0, y_m=0.0, yaw_rad=0.0),
+        )
+
+        self.assertGreater(len(history), 5)
+        self.assertTrue(any(step.observation_used for step in history))
+        self.assertGreater(history[-1].pose.x_m, history[0].pose.x_m)
+
+    def test_lost_target_yields_stop_command(self):
+        behavior = FollowBehavior(smooth_alpha=1.0, target_timeout_s=0.15)
+        track = [
+            TargetPoint(t_s=0.0, x_m=1.5, y_m=0.0),
+            TargetPoint(t_s=0.1, x_m=1.5, y_m=0.0),
+            # Target leaves FOV after this point.
+            TargetPoint(t_s=0.3, x_m=-1.5, y_m=0.0),
+            TargetPoint(t_s=0.5, x_m=-1.5, y_m=0.0),
+        ]
+
+        history = run_follow_simulation_2d(
+            behavior=behavior,
+            target_track=track,
+            dt_s=0.1,
+            initial_pose=Pose2D(x_m=0.0, y_m=0.0, yaw_rad=0.0),
+        )
+
+        self.assertGreater(history[1].linear_mps, 0.0)
+        self.assertEqual(history[-1].linear_mps, 0.0)
+        self.assertEqual(history[-1].angular_rps, 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/vision/test_replay_pipeline.py
+++ b/src/vision/test_replay_pipeline.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Replay tests for the vision detection->tracking->target selection pipeline."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from vision.detection import Detection
+from vision.target_selector import TargetSelector
+from vision.tracker import Tracker
+
+
+class TestVisionReplayPipeline(unittest.TestCase):
+    def test_replay_keeps_target_through_short_occlusion(self):
+        tracker = Tracker(iou_threshold=0.25, max_missed=4)
+        selector = TargetSelector(max_missing_updates=3)
+
+        replay_frames = [
+            [Detection('person', 0.93, 0.40, 0.20, 0.62, 0.88)],
+            [Detection('person', 0.94, 0.41, 0.20, 0.63, 0.88)],
+            [],
+            [Detection('person', 0.91, 0.43, 0.21, 0.65, 0.89)],
+        ]
+
+        selected_ids = []
+        for detections in replay_frames:
+            active_tracks = tracker.update(detections)
+            target = selector.update(active_tracks)
+            selected_ids.append(target.track_id if target else None)
+
+        self.assertEqual(selected_ids[0], selected_ids[1])
+        self.assertIsNone(selected_ids[2])
+        self.assertEqual(selected_ids[3], selected_ids[0])
+
+    def test_replay_prefers_largest_person_when_auto_selecting(self):
+        tracker = Tracker(iou_threshold=0.2, max_missed=3)
+        selector = TargetSelector(max_missing_updates=2)
+
+        frame = [
+            Detection('person', 0.90, 0.10, 0.20, 0.22, 0.55),
+            Detection('person', 0.92, 0.50, 0.18, 0.90, 0.94),
+            Detection('dog', 0.97, 0.20, 0.20, 0.50, 0.60),
+        ]
+
+        active_tracks = tracker.update(frame)
+        target = selector.update(active_tracks)
+
+        self.assertIsNotNone(target)
+        self.assertEqual(target.detection.label, 'person')
+        # Larger person is centered to the right in this replay frame.
+        self.assertGreater(target.detection.cx, 0.6)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/voice/command_intent.py
+++ b/src/voice/command_intent.py
@@ -73,6 +73,7 @@ class CommandIntentParser:
         CommandType.FOLLOW: [
             r'\bfollow\s+(?:the\s+)?(\w+)',  # "follow the person", "follow me"
             r'\bstart\s+following\s+(?:the\s+)?(\w+)',  # "start following person"
+            r'\b(?:keep\s+)?following\s+(?:the\s+)?(\w+)',  # "keep following the person"
         ],
     }
     

--- a/src/voice/test_replay_command_intent.py
+++ b/src/voice/test_replay_command_intent.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Replay tests for voice command parsing sequences."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from voice.command_intent import CommandIntentParser, CommandType
+
+
+class TestVoiceReplayCommandIntent(unittest.TestCase):
+    def test_replay_sequence_parses_follow_and_stop(self):
+        parser = CommandIntentParser()
+        replay_transcripts = [
+            'follow me',
+            'keep following the person',
+            'uh maybe lights blue',
+            'emergency stop now',
+        ]
+
+        commands = [parser.parse(text).command for text in replay_transcripts]
+        self.assertEqual(commands[0], CommandType.FOLLOW)
+        self.assertEqual(commands[1], CommandType.FOLLOW)
+        self.assertEqual(commands[2], CommandType.UNKNOWN)
+        self.assertEqual(commands[3], CommandType.STOP)
+
+    def test_stop_priority_during_replay(self):
+        parser = CommandIntentParser()
+        intent = parser.parse('follow the person but stop immediately')
+        self.assertEqual(intent.command, CommandType.STOP)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/voice/test_replay_command_intent.py
+++ b/src/voice/test_replay_command_intent.py
@@ -5,9 +5,9 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.dirname(__file__))
 
-from voice.command_intent import CommandIntentParser, CommandType
+from command_intent import CommandIntentParser, CommandType
 
 
 class TestVoiceReplayCommandIntent(unittest.TestCase):


### PR DESCRIPTION
Closes #28

## Acceptance Criteria
- [x] Unit tests for core logic
- [x] Replay tests for vision and voice
- [x] 2D simulation for follow behavior

## Required Docs Referenced
- docs/testing/TEST_PLAN.md
- docs/init/TESTING_AND_SIMULATION.md
- docs/init/CONTROL_AND_SAFETY_SPEC.md

## What changed
- Added a deterministic 2D follow simulation harness in `src/control/follow_sim_2d.py`.
- Added unit tests for simulation outcomes in `src/control/test_follow_sim_2d.py`.
- Added vision replay pipeline tests in `src/vision/test_replay_pipeline.py`.
- Added voice transcript replay tests in `src/voice/test_replay_command_intent.py`.
- Extended FOLLOW parser pattern coverage for replay phrase variants in `src/voice/command_intent.py`.
- Updated test strategy docs with implemented replay/simulation suites.

## Tests
- `/Users/rodericktomlinii/src/turbopi-opensource-os/.venv/bin/python -m pytest -q src/control/test_follow_sim_2d.py src/vision/test_replay_pipeline.py src/voice/test_replay_command_intent.py src/control/test_follow_behavior.py src/vision/test_tracker.py src/voice/test_command_intent.py`
