### PR TITLE
Harden updater restart orchestration on robot

### DIFF
--- a/src/updater/apply.py
+++ b/src/updater/apply.py
@@ -26,6 +26,14 @@ from health import verify_release_health, log_failed_service_details, TURBOPI_SE
 logger = logging.getLogger(__name__)
 
 
+# Restart only services that should pick up the new release immediately.
+# The updater service must not restart itself while orchestrating an update.
+UPDATABLE_RUNTIME_SERVICES = [
+    'turbopi-api.service',
+    'turbopi-ui.service',
+]
+
+
 class UpdateError(Exception):
     """Exception raised when update application fails"""
     pass
@@ -101,14 +109,16 @@ def restart_services() -> bool:
     Services are restarted in order:
     1. turbopi-api.service (base service)
     2. turbopi-ui.service (depends on api)
-    3. turbopi-updater.service (last, as it performs the update)
+
+    The updater service is intentionally excluded to avoid self-termination
+    while an update is in progress.
     
     Returns:
         True if all services restarted successfully, False otherwise
     """
     logger.info("Restarting services in dependency order...")
     
-    for service in TURBOPI_SERVICES:
+    for service in UPDATABLE_RUNTIME_SERVICES:
         logger.info(f"Restarting {service}...")
         try:
             result = subprocess.run(

--- a/src/updater/test_apply.py
+++ b/src/updater/test_apply.py
@@ -100,20 +100,29 @@ class TestRestartServices(unittest.TestCase):
     
     @patch('subprocess.run')
     def test_restart_services_success(self, mock_run):
-        """Test successful restart of all services"""
+        """Test successful restart of API/UI services."""
         mock_run.return_value = MagicMock(returncode=0, stderr='')
         
         result = restart_services()
         
         self.assertTrue(result)
         
-        # Verify all three services were restarted in order
-        self.assertEqual(mock_run.call_count, 3)
+        # Verify only API/UI are restarted in order.
+        self.assertEqual(mock_run.call_count, 2)
         calls = mock_run.call_args_list
         
         self.assertIn('turbopi-api.service', calls[0][0][0])
         self.assertIn('turbopi-ui.service', calls[1][0][0])
-        self.assertIn('turbopi-updater.service', calls[2][0][0])
+
+    @patch('subprocess.run')
+    def test_restart_services_does_not_restart_updater(self, mock_run):
+        """Updater service must not be restarted by itself."""
+        mock_run.return_value = MagicMock(returncode=0, stderr='')
+
+        restart_services()
+
+        called = ' '.join(' '.join(call[0][0]) for call in mock_run.call_args_list)
+        self.assertNotIn('turbopi-updater.service', called)
     
     @patch('subprocess.run')
     def test_restart_services_first_fails(self, mock_run):

--- a/system/systemd/turbopi-api.service
+++ b/system/systemd/turbopi-api.service
@@ -21,7 +21,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/var/log/turbopi
+ReadWritePaths=/var/log/turbopi /var/lib/turbopi
 
 [Install]
 WantedBy=multi-user.target

--- a/system/systemd/turbopi-updater.service
+++ b/system/systemd/turbopi-updater.service
@@ -3,7 +3,6 @@ Description=TurboPi Update Service
 Documentation=https://github.com/CteNerd/turbopi-opensource-os
 After=network-online.target turbopi-api.service
 Wants=network-online.target
-BindsTo=turbopi-api.service
 
 [Service]
 Type=simple
@@ -22,7 +21,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/opt/turbopi /var/log/turbopi
+ReadWritePaths=/opt/turbopi /var/log/turbopi /var/lib/turbopi
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Fixes production update rollback caused during service restart phase on real robot.

### Changes
- `src/updater/apply.py`
  - Update restart orchestration to restart only API/UI services.
  - Do not restart updater service from within updater process.
- `src/updater/test_apply.py`
  - Update restart expectations to API/UI-only.
  - Add coverage asserting updater service is not restarted.
- `system/systemd/turbopi-api.service`
  - Add `/var/lib/turbopi` to `ReadWritePaths` so API can write updater trigger file.
- `system/systemd/turbopi-updater.service`
  - Remove `BindsTo=turbopi-api.service` to avoid updater termination during API restart.
  - Add `/var/lib/turbopi` to `ReadWritePaths` for trigger consumption.

## Validation
- Focused updater tests for modified restart/symlink/rollback behavior pass:
  - `pytest src/updater/test_apply.py -k "restart_services or switch_to_release or rollback_to_previous" -q`
- Full updater suite still has existing environment-permission failures when tests touch `/opt/turbopi` in this host setup.

## Why this fixes production
On-robot logs showed install/symlink switch succeeding and rollback being triggered at restart step. This change removes self-termination/coupling and ensures trigger IPC path permissions for both API and updater under systemd sandboxing.