### PR TITLE
(#76) Fix overlay pointer capture for drive and head joysticks

### DIFF
--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -1311,6 +1311,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             }}
 
             pad.addEventListener('pointerdown', (event) => {{
+                event.preventDefault();
                 active = true;
                 pad.setPointerCapture(event.pointerId);
                 updateFromEvent(event);
@@ -1318,6 +1319,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
             pad.addEventListener('pointermove', (event) => {{
                 if (!active) return;
+                event.preventDefault();
                 updateFromEvent(event);
             }});
 
@@ -1328,7 +1330,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
             pad.addEventListener('pointerup', release);
             pad.addEventListener('pointercancel', release);
-            pad.addEventListener('pointerleave', () => {{ if (active) release(); }});
+            pad.addEventListener('lostpointercapture', () => {{ if (active) release(); }});
         }}
 
         function setupHeadOverlayJoystick() {{
@@ -1370,6 +1372,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             }}
 
             pad.addEventListener('pointerdown', (event) => {{
+                event.preventDefault();
                 active = true;
                 pad.setPointerCapture(event.pointerId);
                 mapToHead(event);
@@ -1377,6 +1380,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
             pad.addEventListener('pointermove', (event) => {{
                 if (!active) return;
+                event.preventDefault();
                 mapToHead(event);
             }});
 
@@ -1386,7 +1390,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
             pad.addEventListener('pointerup', release);
             pad.addEventListener('pointercancel', release);
-            pad.addEventListener('pointerleave', () => {{ if (active) release(); }});
+            pad.addEventListener('lostpointercapture', () => {{ if (active) release(); }});
         }}
 
         function setupJoystick() {{


### PR DESCRIPTION
## Summary

Fixes drive and head overlay joystick controls losing pointer events on mobile and desktop.

## Changes
- `preventDefault()` on `pointerdown`/`pointermove` stops scroll/browser gestures from stealing pointer events
- Replaced `pointerleave` with `lostpointercapture` for reliable release detection when pointer leaves element bounds
- Both drive overlay pad and head overlay pad receive the same fix

## Testing
- 19 targeted control/API tests pass
- WebSocket messages confirmed flowing to robot (verified via journalctl)