### PR TITLE
(release) Prepare 0.1.17 runtime fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,19 @@ jobs:
           mkdir -p "$STAGING/bin"
           mkdir -p "$STAGING/systemd"
 
+          # Preserve optional runtime-only vendor assets when they are present in
+          # the working tree used for the release build.
+          for optional_dir in HiwonderSDK; do
+            if [ -d "$optional_dir" ]; then
+              cp -R "$optional_dir" "$STAGING/$optional_dir"
+            fi
+          done
+          for optional_file in servo_config.yaml; do
+            if [ -f "$optional_file" ]; then
+              cp "$optional_file" "$STAGING/$optional_file"
+            fi
+          done
+
           # Copy source modules (skip test files and __pycache__)
           for module in api ui updater control hal vision voice; do
             [ -d "src/$module" ] || continue

--- a/docs/config/SCHEMA.md
+++ b/docs/config/SCHEMA.md
@@ -18,12 +18,15 @@ MAX_ANGULAR_SPEED=1.2
 DEADMAN_TIMEOUT_MS=500
 MANUAL_OVERRIDE_TIMEOUT_MS=500
 API_WS_PORT=8765
+UI_DRIVE_INVERT_STEERING=false
 
 HAL_MOTOR_LEFT_TRIM=0.0
 HAL_MOTOR_RIGHT_TRIM=0.0
 HAL_MOTOR_LEFT_SCALE=1.0
 HAL_MOTOR_RIGHT_SCALE=1.0
 
+HAL_CAMERA_BACKEND=auto
+HAL_CAMERA_DEVICE=-1
 HAL_CAMERA_WIDTH=640
 HAL_CAMERA_HEIGHT=480
 HAL_CAMERA_FPS=30
@@ -42,3 +45,5 @@ DOWNLOAD_DIR=/opt/turbopi/downloads
 - Loaded via systemd EnvironmentFile
 - UI edits must validate before write
 - HAL calibration values should fail safe if missing or invalid by falling back to conservative defaults
+- UI_DRIVE_INVERT_STEERING flips joystick left/right in the web UI without changing backend safety logic
+- HAL_CAMERA_BACKEND supports `auto` or `opencv`; HAL_CAMERA_DEVICE selects the V4L device index used for MJPEG streaming

--- a/docs/ui/UI_BEHAVIOR.md
+++ b/docs/ui/UI_BEHAVIOR.md
@@ -32,6 +32,7 @@
 - Joystick release sends stop command
 - WebSocket disconnect or heartbeat timeout must stop motion immediately
 - UI polls control state to display Armed, E-Stop latched, and deadman status
+- `UI_DRIVE_INVERT_STEERING=true` flips joystick steering in the UI for kits with mirrored left/right turning behavior
 
 ## Vision Page
 - UI displays live MJPEG stream from GET /video/stream

--- a/docs/updater/RELEASE_INSTALL_LAYOUT.md
+++ b/docs/updater/RELEASE_INSTALL_LAYOUT.md
@@ -31,6 +31,8 @@ The release install layout supports:
 │   │   │   ├── turbopi-api.service
 │   │   │   ├── turbopi-ui.service
 │   │   │   └── turbopi-updater.service
+│   │   ├── HiwonderSDK/  # Optional preserved vendor SDK when present on target
+│   │   ├── servo_config.yaml # Optional preserved vendor servo centers
 │   │   ├── lib/          # Shared libraries (if needed)
 │   │   └── metadata.json # Release metadata and checksums
 │   ├── 0.1.1/            # Example: Release version 0.1.1
@@ -51,6 +53,10 @@ The release install layout supports:
 /var/lib/turbopi/         # Persistent state data (shared across versions)
 └── ...
 ```
+
+Vendor runtime assets such as `HiwonderSDK/` and `servo_config.yaml` are not
+stored in this repository, but installer and updater flows preserve them into
+new releases when they already exist on the target robot.
 
 ## Symlink Strategy
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -130,7 +130,7 @@ def get_current_version() -> str:
     except Exception:
         pass  # Fall through to environment variable
     
-    return os.environ.get('VERSION', '0.1.0-dev')
+    return os.environ.get('VERSION', '0.1.17')
 
 
 def redact_secrets(text: str) -> str:

--- a/src/api/test_main.py
+++ b/src/api/test_main.py
@@ -35,7 +35,7 @@ class TestGetCurrentVersion(unittest.TestCase):
         """Test default version when VERSION env var is not set"""
         with patch.dict(os.environ, {}, clear=True):
             result = get_current_version()
-            self.assertEqual(result, '0.1.0-dev')
+            self.assertEqual(result, '0.1.17')
     
     def test_get_version_with_dev_suffix(self):
         """Test version with -dev suffix"""

--- a/src/hal/README.md
+++ b/src/hal/README.md
@@ -22,6 +22,10 @@ This module currently provides:
 The HAL does not replace the Safety Arbiter. It is the hardware-facing layer
 that safety and control modules call.
 
+Angular sign convention:
+- Positive `angular_rps` means turn right.
+- Negative `angular_rps` means turn left.
+
 ## Modules
 
 - `motor.py`: velocity commands, normalized outputs, arm/disarm/stop behavior

--- a/src/hal/motor.py
+++ b/src/hal/motor.py
@@ -197,8 +197,8 @@ class BaseMotorHAL(ABC):
             1.0,
         )
 
-        left_output = ((linear_norm - angular_norm) * self.calibration.left_scale) + self.calibration.left_trim
-        right_output = ((linear_norm + angular_norm) * self.calibration.right_scale) + self.calibration.right_trim
+        left_output = ((linear_norm + angular_norm) * self.calibration.left_scale) + self.calibration.left_trim
+        right_output = ((linear_norm - angular_norm) * self.calibration.right_scale) + self.calibration.right_trim
 
         return (
             _clamp(left_output, -1.0, 1.0),

--- a/src/hal/test_motor.py
+++ b/src/hal/test_motor.py
@@ -74,9 +74,21 @@ class TestMotorCalibration(unittest.TestCase):
             VelocityCommand(linear_mps=1.0, angular_rps=1.0)
         )
 
-        self.assertEqual(left_output, 0.1)
-        self.assertEqual(right_output, 1.0)
+        self.assertEqual(left_output, 1.0)
+        self.assertEqual(right_output, -0.1)
         self.assertEqual(hal.get_state().last_command.linear_mps, 1.0)
+
+    def test_positive_angular_biases_left_side_for_right_turn(self):
+        hal = SimulatedMotorHAL(
+            calibration=MotorCalibration(max_linear_speed=1.0, max_angular_speed=1.0)
+        )
+        hal.arm()
+
+        left_output, right_output = hal.set_velocity(
+            VelocityCommand(linear_mps=0.0, angular_rps=0.5)
+        )
+
+        self.assertGreater(left_output, right_output)
 
     def test_stop_zeroes_outputs(self):
         hal = SimulatedMotorHAL()
@@ -96,6 +108,19 @@ class TestMotorCalibration(unittest.TestCase):
 
         # Forward command should drive all channels with vendor sign convention.
         self.assertEqual(board.calls[-1], [[1, -25], [2, 25], [3, -25], [4, 25]])
+
+    def test_vendor_hal_positive_angular_turns_right(self):
+        board = FakeBoard()
+        hal = HiwonderTurboPiMotorHAL(
+            board=board,
+            calibration=MotorCalibration(max_linear_speed=1.0, max_angular_speed=1.0),
+            max_duty=50,
+        )
+        hal.arm()
+
+        hal.set_velocity(VelocityCommand(linear_mps=0.0, angular_rps=0.5))
+
+        self.assertEqual(board.calls[-1], [[1, -25], [2, -25], [3, -25], [4, -25]])
 
     def test_vendor_hal_blocks_nonzero_output_on_disabled_channel(self):
         board = FakeBoard()

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -705,6 +705,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         const VIDEO_STREAM_PATH = '/video/stream';
         const VIDEO_STATS_PATH = '/video/stats';
         const VIDEO_STREAM_SECONDS = 3600;
+        const DRIVE_ANGULAR_SIGN = {drive_angular_sign};
         let controlSocket = null;
         let heartbeatTimer = null;
         let controlReconnectTimer = null;
@@ -1306,7 +1307,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
                 knob.style.top = (center + dy) + 'px';
 
                 const linear = (-dy / radius) * controlMaxLinear;
-                const angular = (dx / radius) * controlMaxAngular;
+                const angular = (dx / radius) * controlMaxAngular * DRIVE_ANGULAR_SIGN;
                 sendDrive(linear, angular);
             }}
 
@@ -1726,8 +1727,15 @@ class UIHandler(SimpleHTTPRequestHandler):
             robot_name = os.environ.get('ROBOT_NAME', 'TurboPi')
             api_port = os.environ.get('API_PORT', '8080')
             ws_port = os.environ.get('API_WS_PORT', '8765')
+            drive_invert = os.environ.get('UI_DRIVE_INVERT_STEERING', 'false').strip().lower()
+            drive_angular_sign = -1 if drive_invert in ('1', 'true', 'yes', 'on') else 1
             
-            html = HTML_TEMPLATE.format(robot_name=robot_name, api_port=api_port, ws_port=ws_port)
+            html = HTML_TEMPLATE.format(
+                robot_name=robot_name,
+                api_port=api_port,
+                ws_port=ws_port,
+                drive_angular_sign=drive_angular_sign,
+            )
             self.wfile.write(html.encode())
         else:
             self.send_error(404, "Not Found")

--- a/src/updater/install.py
+++ b/src/updater/install.py
@@ -24,6 +24,48 @@ from typing import Dict, Optional
 logger = logging.getLogger(__name__)
 
 
+OPTIONAL_VENDOR_SDK_PATHS = (
+    '/opt/turbopi/current/HiwonderSDK',
+    '/home/pi/TurboPi/HiwonderSDK',
+    '/home/pi/backup/HiwonderSDK',
+)
+
+OPTIONAL_SERVO_CONFIG_PATHS = (
+    '/opt/turbopi/current/servo_config.yaml',
+    '/home/pi/TurboPi/servo_config.yaml',
+)
+
+
+def _copytree_if_present(source_dir: str, dest_dir: str) -> bool:
+    """Copy a directory tree into the release when the source exists."""
+    if not os.path.isdir(source_dir):
+        return False
+    if os.path.exists(dest_dir):
+        return True
+    shutil.copytree(source_dir, dest_dir)
+    logger.info("Preserved optional runtime asset from %s to %s", source_dir, dest_dir)
+    return True
+
+
+def preserve_optional_runtime_assets(release_dir: str) -> None:
+    """Carry forward runtime-only vendor assets that are not shipped in git releases."""
+    sdk_dest = os.path.join(release_dir, 'HiwonderSDK')
+    servo_dest = os.path.join(release_dir, 'servo_config.yaml')
+
+    for sdk_source in OPTIONAL_VENDOR_SDK_PATHS:
+        if _copytree_if_present(sdk_source, sdk_dest):
+            break
+    else:
+        logger.warning('Optional vendor SDK not found in known locations; vendor HAL may be unavailable')
+
+    if not os.path.exists(servo_dest):
+        for servo_source in OPTIONAL_SERVO_CONFIG_PATHS:
+            if os.path.isfile(servo_source):
+                shutil.copy2(servo_source, servo_dest)
+                logger.info('Preserved servo configuration from %s to %s', servo_source, servo_dest)
+                break
+
+
 class InstallError(Exception):
     """Exception raised when installation fails"""
     pass
@@ -101,6 +143,8 @@ def extract_tarball(tarball_path: str, dest_dir: str) -> None:
         raise InstallError(f"Unexpected error during extraction: {e}")
     
     logger.info(f"Extraction complete: {dest_dir}")
+
+    preserve_optional_runtime_assets(dest_dir)
     
     # Fix ownership: services run as turbopi user, so release directory must be accessible.
     # On production robots, turbopi:turbopi ownership is required for services to access files.

--- a/src/updater/main.py
+++ b/src/updater/main.py
@@ -352,7 +352,7 @@ class UpdaterService:
             logging.warning('Auto-update scheduler: could not fetch release metadata')
             return
 
-        current = os.environ.get('VERSION', '0.1.0-dev')
+        current = os.environ.get('VERSION', '0.1.17')
         latest = release.get('version', '')
         if not self._is_newer_version(current, latest):
             logging.info(

--- a/src/updater/test_install.py
+++ b/src/updater/test_install.py
@@ -9,14 +9,17 @@ import tempfile
 import tarfile
 import shutil
 import unittest
+from unittest.mock import patch
 from install import (
+    OPTIONAL_VENDOR_SDK_PATHS,
     extract_tarball,
     validate_release_structure,
     create_metadata,
     update_metadata_health_status,
     install_release,
     get_release_metadata,
-    InstallError
+    InstallError,
+    preserve_optional_runtime_assets,
 )
 
 
@@ -78,6 +81,23 @@ class TestExtractTarball(unittest.TestCase):
             extract_tarball(tarball_path, dest_dir)
         
         self.assertIn('Unsafe path', str(cm.exception))
+
+    def test_preserve_optional_runtime_assets_copies_current_release_sdk(self):
+        release_dir = os.path.join(self.temp_dir, 'release')
+        current_dir = os.path.join(self.temp_dir, 'current')
+        sdk_dir = os.path.join(current_dir, 'HiwonderSDK')
+        os.makedirs(release_dir)
+        os.makedirs(sdk_dir)
+
+        with open(os.path.join(sdk_dir, 'ros_robot_controller_sdk.py'), 'w') as f:
+            f.write('class Board:\n    pass\n')
+
+        fake_sdk_paths = (sdk_dir,) + tuple(path for path in OPTIONAL_VENDOR_SDK_PATHS if path != sdk_dir)
+        with patch('install.OPTIONAL_VENDOR_SDK_PATHS', fake_sdk_paths):
+            preserve_optional_runtime_assets(release_dir)
+
+        self.assertTrue(os.path.isdir(os.path.join(release_dir, 'HiwonderSDK')))
+        self.assertTrue(os.path.isfile(os.path.join(release_dir, 'HiwonderSDK', 'ros_robot_controller_sdk.py')))
 
 
 class TestValidateReleaseStructure(unittest.TestCase):

--- a/system/config.env.example
+++ b/system/config.env.example
@@ -7,7 +7,7 @@ ROBOT_NAME=TurboPi
 WAKE_WORD=Jarvis
 WAKE_WORD_ENABLED=true
 WAKE_WORD_TIMEOUT=5
-VERSION=0.1.0-dev
+VERSION=0.1.17
 
 # === Service Configuration ===
 API_HOST=0.0.0.0
@@ -15,6 +15,8 @@ API_PORT=8080
 API_WS_PORT=8765
 UI_HOST=0.0.0.0
 UI_PORT=8081
+# Set true if the joystick steering direction is mirrored on the target kit.
+UI_DRIVE_INVERT_STEERING=false
 
 # === Cloud Services (Optional) ===
 # These credentials are only required if using cloud-based AI features
@@ -68,6 +70,8 @@ HAL_HEAD_TILT_PULSE_MAX=2000
 # HAL_HEAD_PAN_PULSE_CENTER=1500
 # HAL_HEAD_TILT_PULSE_CENTER=1500
 HAL_HEAD_MOVE_TIME_S=0.05
+HAL_CAMERA_BACKEND=auto
+HAL_CAMERA_DEVICE=-1
 HAL_CAMERA_WIDTH=640
 HAL_CAMERA_HEIGHT=480
 HAL_CAMERA_FPS=30

--- a/system/install-services.sh
+++ b/system/install-services.sh
@@ -38,28 +38,45 @@ echo "Installing service binaries..."
 cp -r "$REPO_ROOT/src/api" /opt/turbopi/current/src/
 cp -r "$REPO_ROOT/src/ui" /opt/turbopi/current/src/
 cp -r "$REPO_ROOT/src/updater" /opt/turbopi/current/src/
+cp -r "$REPO_ROOT/src/control" /opt/turbopi/current/src/
+cp -r "$REPO_ROOT/src/hal" /opt/turbopi/current/src/
+cp -r "$REPO_ROOT/src/vision" /opt/turbopi/current/src/
 cp -r "$REPO_ROOT/src/voice" /opt/turbopi/current/src/
+
+if [ -d /home/pi/TurboPi/HiwonderSDK ] && [ ! -d /opt/turbopi/current/HiwonderSDK ]; then
+    echo "Preserving vendor SDK from /home/pi/TurboPi/HiwonderSDK..."
+    cp -r /home/pi/TurboPi/HiwonderSDK /opt/turbopi/current/
+fi
+
+if [ -f /home/pi/TurboPi/servo_config.yaml ] && [ ! -f /opt/turbopi/current/servo_config.yaml ]; then
+    echo "Preserving vendor servo configuration from /home/pi/TurboPi/servo_config.yaml..."
+    cp /home/pi/TurboPi/servo_config.yaml /opt/turbopi/current/
+fi
 
 # Create wrapper scripts in bin directory
 echo "Creating service wrappers..."
 
 cat > /opt/turbopi/current/bin/api << 'EOF'
 #!/bin/bash
+cd /opt/turbopi/current || exit 1
 exec /usr/bin/python3 /opt/turbopi/current/src/api/main.py
 EOF
 
 cat > /opt/turbopi/current/bin/ui << 'EOF'
 #!/bin/bash
+cd /opt/turbopi/current || exit 1
 exec /usr/bin/python3 /opt/turbopi/current/src/ui/main.py
 EOF
 
 cat > /opt/turbopi/current/bin/updater << 'EOF'
 #!/bin/bash
+cd /opt/turbopi/current || exit 1
 exec /usr/bin/python3 /opt/turbopi/current/src/updater/main.py
 EOF
 
 cat > /opt/turbopi/current/bin/wake-word << 'EOF'
 #!/bin/bash
+cd /opt/turbopi/current || exit 1
 exec /usr/bin/python3 /opt/turbopi/current/src/voice/main.py
 EOF
 


### PR DESCRIPTION
## Summary
Prepare release `0.1.17` with the runtime fixes validated on hardware.

## Acceptance Criteria
- [x] Preserve vendor runtime assets (`HiwonderSDK`, `servo_config.yaml`) across install/update flows when they already exist on the robot
- [x] Correct motor angular sign so positive angular commands turn right across manual and behavior-driven motion paths
- [x] Add camera and steering configuration/docs for long-lived field configuration
- [x] Bump release defaults to `0.1.17`

## Required Docs
- [docs/updater/RELEASE_INSTALL_LAYOUT.md](docs/updater/RELEASE_INSTALL_LAYOUT.md)
- [docs/config/SCHEMA.md](docs/config/SCHEMA.md)
- [docs/ui/UI_BEHAVIOR.md](docs/ui/UI_BEHAVIOR.md)

## Validation
- `python3 -m unittest src/hal/test_motor.py src/updater/test_install.py src/api/test_main.py src/control/test_follow_behavior.py`
- `python3 -m py_compile src/hal/motor.py src/ui/main.py src/updater/install.py src/api/main.py`

## Questions/Assumptions
- No linked issue number was provided for this release PR, so the title uses the existing release format.
- The GitHub release tarball remains license-clean by preserving vendor runtime assets on target install/update rather than vendoring them into the repository.
